### PR TITLE
Bind Astro dev server to all interfaces

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,9 @@ import favicons from "astro-favicons";
 // https://astro.build/config
 export default defineConfig({
   site: "https://tricity-hiking.ertrzyiks.me",
+  server: {
+    host: "0.0.0.0",
+  },
   integrations: [
     mdx(),
     preact(),


### PR DESCRIPTION
## Summary
- Set `server.host` to `0.0.0.0` in `astro.config.mjs` so the Astro dev server listens on all interfaces instead of just loopback, making it reachable through published sandbox ports.

## Test plan
- [x] `pnpm test` — 25 tests passed
- [x] Verified dev server responds with 200 on `0.0.0.0:4321` and is reachable via published port

🤖 Generated with [Claude Code](https://claude.com/claude-code)