### PR TITLE
Prototype: swipeable card deck for browsing routes (/discover)

### DIFF
--- a/src/components/ui/CardDeck/CardDeck.tsx
+++ b/src/components/ui/CardDeck/CardDeck.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../../services/cardDeck";
 import type { DeckCard } from "./types";
 import { trackEvent } from "../../../services/analytics";
+import { Button } from "../Button/Button";
 
 const SWIPE_THRESHOLD = 60;
 
@@ -14,6 +15,9 @@ const DECK_LABELS: Record<DeckKey, string> = {
   tricity: "Tricity",
   nearby: "Nearby",
 };
+
+const getSlugFromURL = () =>
+  new URL(window.location.href).searchParams.get("route");
 
 const updateURL = (slug: string) => {
   const url = new URL(window.location.href);
@@ -31,23 +35,37 @@ export const CardDeck = ({ decks }: { decks: Record<DeckKey, DeckCard[]> }) => {
   const cards = decks[activeDeck];
   const card = cards[activeIndex] as DeckCard | undefined;
 
-  // Restore deck/index from a shared `?route=<slug>` URL on first mount.
+  // Restore deck/index from a shared `?route=<slug>` URL: on first mount,
+  // and again on browser back/forward so the deck follows history rather
+  // than just the address bar.
   useEffect(() => {
-    const slug = new URL(window.location.href).searchParams.get("route");
-    const located = locateCardBySlug(decks, slug);
+    const restoreFromURL = () => {
+      const located = locateCardBySlug(decks, getSlugFromURL());
 
-    if (located) {
-      setActiveDeck(located.deckKey);
-      setActiveIndex(located.index);
-    }
+      if (located) {
+        setActiveDeck(located.deckKey);
+        setActiveIndex(located.index);
+      }
+    };
 
+    restoreFromURL();
     hasRestoredFromURL.current = true;
+
+    window.addEventListener("popstate", restoreFromURL);
+    return () => window.removeEventListener("popstate", restoreFromURL);
   }, []);
 
   // Keep the URL in sync so a given card is shareable/bookmarkable, without
-  // triggering a full navigation.
+  // triggering a full navigation. Skipped when the URL already points at
+  // this card, so restoring state from a `popstate` event doesn't turn
+  // right back around and push a new entry on top of the one the user
+  // just navigated back to.
   useEffect(() => {
     if (!hasRestoredFromURL.current || !card) {
+      return;
+    }
+
+    if (getSlugFromURL() === card.slug) {
       return;
     }
 
@@ -175,7 +193,7 @@ export const CardDeck = ({ decks }: { decks: Record<DeckKey, DeckCard[]> }) => {
             />
           )}
 
-          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent pointer-events-none" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent pointer-events-none" />
 
           <div className="absolute inset-x-0 bottom-0 p-6 text-white pointer-events-none">
             <h2 className="text-2xl font-bold mb-1">{card.title}</h2>
@@ -212,13 +230,9 @@ export const CardDeck = ({ decks }: { decks: Record<DeckKey, DeckCard[]> }) => {
               </div>
             </div>
 
-            <button
-              type="button"
-              onClick={openDetail}
-              className="pointer-events-auto select-none rounded-lg bg-green-500 py-3 px-6 text-center align-middle font-sans text-xs font-bold uppercase text-white shadow-md shadow-green-900/10 transition-all hover:shadow-lg hover:shadow-green-900/20"
-            >
-              View route →
-            </button>
+            <div className="pointer-events-auto inline-block">
+              <Button onClick={openDetail}>View route →</Button>
+            </div>
           </div>
         </div>
 

--- a/src/components/ui/CardDeck/CardDeck.tsx
+++ b/src/components/ui/CardDeck/CardDeck.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import {
+  clampIndex,
+  locateCardBySlug,
+  resolveSwipeAction,
+  type DeckKey,
+} from "../../../services/cardDeck";
+import type { DeckCard } from "./types";
+import { trackEvent } from "../../../services/analytics";
+
+const SWIPE_THRESHOLD = 60;
+
+const DECK_LABELS: Record<DeckKey, string> = {
+  tricity: "Tricity",
+  nearby: "Nearby",
+};
+
+const updateURL = (slug: string) => {
+  const url = new URL(window.location.href);
+  url.searchParams.set("route", slug);
+  window.history.pushState({}, "", url);
+};
+
+export const CardDeck = ({ decks }: { decks: Record<DeckKey, DeckCard[]> }) => {
+  const [activeDeck, setActiveDeck] = useState<DeckKey>("tricity");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [dragX, setDragX] = useState(0);
+  const hasRestoredFromURL = useRef(false);
+  const dragStart = useRef<{ x: number; y: number } | null>(null);
+
+  const cards = decks[activeDeck];
+  const card = cards[activeIndex] as DeckCard | undefined;
+
+  // Restore deck/index from a shared `?route=<slug>` URL on first mount.
+  useEffect(() => {
+    const slug = new URL(window.location.href).searchParams.get("route");
+    const located = locateCardBySlug(decks, slug);
+
+    if (located) {
+      setActiveDeck(located.deckKey);
+      setActiveIndex(located.index);
+    }
+
+    hasRestoredFromURL.current = true;
+  }, []);
+
+  // Keep the URL in sync so a given card is shareable/bookmarkable, without
+  // triggering a full navigation.
+  useEffect(() => {
+    if (!hasRestoredFromURL.current || !card) {
+      return;
+    }
+
+    updateURL(card.slug);
+  }, [activeDeck, activeIndex, card]);
+
+  const goNext = () => {
+    setActiveIndex((index) => clampIndex(index + 1, cards.length));
+  };
+
+  const goPrev = () => {
+    setActiveIndex((index) => clampIndex(index - 1, cards.length));
+  };
+
+  const openDetail = () => {
+    if (!card) {
+      return;
+    }
+
+    trackEvent("discover card opened", { slug: card.slug });
+    window.location.href = `/routes/${card.slug}/`;
+  };
+
+  const switchDeck = (deckKey: DeckKey) => {
+    if (deckKey === activeDeck) {
+      return;
+    }
+
+    setActiveDeck(deckKey);
+    setActiveIndex(0);
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft") {
+        goPrev();
+      } else if (event.key === "ArrowRight") {
+        goNext();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  });
+
+  const handlePointerDown = (event: PointerEvent) => {
+    dragStart.current = { x: event.clientX, y: event.clientY };
+    (event.target as HTMLElement).setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (!dragStart.current) {
+      return;
+    }
+
+    setDragX(event.clientX - dragStart.current.x);
+  };
+
+  const handlePointerUp = (event: PointerEvent) => {
+    if (!dragStart.current) {
+      return;
+    }
+
+    const deltaX = event.clientX - dragStart.current.x;
+    const deltaY = event.clientY - dragStart.current.y;
+    const action = resolveSwipeAction(deltaX, deltaY, SWIPE_THRESHOLD);
+
+    dragStart.current = null;
+    setDragX(0);
+
+    if (action === "next") {
+      goNext();
+    } else if (action === "prev") {
+      goPrev();
+    } else if (action === "open") {
+      openDetail();
+    }
+  };
+
+  if (!card) {
+    return (
+      <div className="flex items-center justify-center h-full text-slate-500">
+        No routes in this deck yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-center gap-2 py-3">
+        {(Object.keys(decks) as DeckKey[]).map((deckKey) => (
+          <button
+            key={deckKey}
+            type="button"
+            onClick={() => switchDeck(deckKey)}
+            className={`rounded-full px-4 py-1.5 text-sm font-semibold uppercase transition-colors ${
+              deckKey === activeDeck
+                ? "bg-green-500 text-white"
+                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+          >
+            {DECK_LABELS[deckKey]} ({decks[deckKey].length})
+          </button>
+        ))}
+      </div>
+
+      <div className="relative flex-1 min-h-0 overflow-hidden rounded-2xl bg-slate-800 select-none">
+        <div
+          className="absolute inset-0 touch-pan-y"
+          style={{
+            transform: `translateX(${dragX}px)`,
+            transition: dragStart.current ? "none" : "transform 200ms ease",
+          }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+        >
+          {card.previewSrc && (
+            <img
+              src={card.previewSrc}
+              alt=""
+              className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+              draggable={false}
+            />
+          )}
+
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent pointer-events-none" />
+
+          <div className="absolute inset-x-0 bottom-0 p-6 text-white pointer-events-none">
+            <h2 className="text-2xl font-bold mb-1">{card.title}</h2>
+            <p className="text-sm text-slate-200 mb-4 line-clamp-2">
+              {card.description}
+            </p>
+
+            <div className="grid grid-cols-2 gap-3 mb-4 max-w-sm">
+              <div>
+                <div className="text-lg font-semibold">
+                  {card.distanceKm.toFixed(2)}km
+                </div>
+                <div className="text-xs uppercase text-slate-300">Distance</div>
+              </div>
+              <div>
+                <div className="text-lg font-semibold">{card.time}</div>
+                <div className="text-xs uppercase text-slate-300">Time</div>
+              </div>
+              <div>
+                <div className="text-lg font-semibold">
+                  {card.totalGain.toFixed(0)}m
+                </div>
+                <div className="text-xs uppercase text-slate-300">
+                  Total Gain
+                </div>
+              </div>
+              <div>
+                <div className="text-lg font-semibold">
+                  {card.totalLoss.toFixed(0)}m
+                </div>
+                <div className="text-xs uppercase text-slate-300">
+                  Total Loss
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={openDetail}
+              className="pointer-events-auto select-none rounded-lg bg-green-500 py-3 px-6 text-center align-middle font-sans text-xs font-bold uppercase text-white shadow-md shadow-green-900/10 transition-all hover:shadow-lg hover:shadow-green-900/20"
+            >
+              View route →
+            </button>
+          </div>
+        </div>
+
+        {activeIndex > 0 && (
+          <button
+            type="button"
+            aria-label="Previous route"
+            onClick={goPrev}
+            className="hidden md:flex absolute left-4 top-1/2 -translate-y-1/2 items-center justify-center w-12 h-12 rounded-full bg-black/40 text-white hover:bg-black/60 transition-colors"
+          >
+            <ChevronIcon direction="left" />
+          </button>
+        )}
+
+        {activeIndex < cards.length - 1 && (
+          <button
+            type="button"
+            aria-label="Next route"
+            onClick={goNext}
+            className="hidden md:flex absolute right-4 top-1/2 -translate-y-1/2 items-center justify-center w-12 h-12 rounded-full bg-black/40 text-white hover:bg-black/60 transition-colors"
+          >
+            <ChevronIcon direction="right" />
+          </button>
+        )}
+      </div>
+
+      <div className="text-center py-3 text-sm text-slate-500">
+        {activeIndex + 1} / {cards.length}
+      </div>
+    </div>
+  );
+};
+
+const ChevronIcon = ({ direction }: { direction: "left" | "right" }) => (
+  <svg
+    viewBox="0 0 24 24"
+    width="24"
+    height="24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline
+      points={direction === "left" ? "15 18 9 12 15 6" : "9 18 15 12 9 6"}
+    />
+  </svg>
+);

--- a/src/components/ui/CardDeck/types.ts
+++ b/src/components/ui/CardDeck/types.ts
@@ -1,0 +1,10 @@
+export interface DeckCard {
+  slug: string;
+  title: string;
+  description: string;
+  previewSrc: string | null;
+  distanceKm: number;
+  time: string;
+  totalGain: number;
+  totalLoss: number;
+}

--- a/src/pages/discover.astro
+++ b/src/pages/discover.astro
@@ -1,0 +1,63 @@
+---
+import { getCollection, getEntry } from "astro:content";
+import { getImage } from "astro:assets";
+import Layout from "../layouts/Layout.astro";
+import { enhance } from "../services/enhance";
+import { getLineStringFeature } from "../services/getLineStringFeature";
+import { mToKm } from "../services/mToKm";
+import { formatTime } from "../services/formatTime";
+import { CardDeck } from "../components/ui/CardDeck/CardDeck";
+import type { DeckCard } from "../components/ui/CardDeck/types";
+import type { CollectionEntry } from "astro:content";
+
+async function buildDeck(
+  routes: CollectionEntry<"routes">[],
+): Promise<DeckCard[]> {
+  const cards: DeckCard[] = [];
+
+  for (const route of routes) {
+    const geojson = await getEntry(route.data.geojson);
+    const enhancedGeojson = enhance({
+      collection: geojson.data,
+      route: route.data,
+    });
+    const properties =
+      getLineStringFeature({ collection: enhancedGeojson })?.properties ?? {};
+
+    const previewImage = route.data.preview
+      ? await getImage({
+          src: route.data.preview,
+          width: 1200,
+          height: 1600,
+        })
+      : null;
+
+    cards.push({
+      slug: route.id,
+      title: route.data.title,
+      description: route.data.description,
+      previewSrc: previewImage?.src ?? null,
+      distanceKm: mToKm(properties.distance ?? 0),
+      time: formatTime(properties.estimatedTime ?? 0),
+      totalGain: properties.totalGain ?? 0,
+      totalLoss: properties.totalLoss ?? 0,
+    });
+  }
+
+  return cards;
+}
+
+const allRoutes = await getCollection("routes");
+const routes = allRoutes.filter((route) => !route.data.draft);
+
+const decks = {
+  tricity: await buildDeck(routes.filter((route) => route.data.tricity)),
+  nearby: await buildDeck(routes.filter((route) => !route.data.tricity)),
+};
+---
+
+<Layout title="Discover hiking trails near Gdańsk, Sopot, and Gdynia">
+  <div class="max-w-(--breakpoint-md) mx-auto h-[80vh] min-h-[500px]">
+    <CardDeck client:load decks={decks} />
+  </div>
+</Layout>

--- a/src/services/cardDeck.test.ts
+++ b/src/services/cardDeck.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampIndex,
+  locateCardBySlug,
+  resolveSwipeAction,
+  type DeckKey,
+} from "./cardDeck";
+
+describe("cardDeck", () => {
+  describe("clampIndex", () => {
+    it("keeps an in-range index unchanged", () => {
+      expect(clampIndex(2, 5)).toBe(2);
+    });
+
+    it("clamps an index below zero to zero", () => {
+      expect(clampIndex(-3, 5)).toBe(0);
+    });
+
+    it("clamps an index at or beyond the length to the last item", () => {
+      expect(clampIndex(5, 5)).toBe(4);
+      expect(clampIndex(99, 5)).toBe(4);
+    });
+
+    it("returns zero for an empty deck", () => {
+      expect(clampIndex(3, 0)).toBe(0);
+    });
+  });
+
+  describe("locateCardBySlug", () => {
+    const decks: Record<DeckKey, { slug: string }[]> = {
+      tricity: [{ slug: "a" }, { slug: "b" }],
+      nearby: [{ slug: "c" }, { slug: "d" }],
+    };
+
+    it("finds a card in the first deck that matches", () => {
+      expect(locateCardBySlug(decks, "b")).toEqual({
+        deckKey: "tricity",
+        index: 1,
+      });
+    });
+
+    it("finds a card in another deck when not in the first", () => {
+      expect(locateCardBySlug(decks, "d")).toEqual({
+        deckKey: "nearby",
+        index: 1,
+      });
+    });
+
+    it("returns null when the slug is not present in any deck", () => {
+      expect(locateCardBySlug(decks, "missing")).toBeNull();
+    });
+
+    it("returns null when the slug is null", () => {
+      expect(locateCardBySlug(decks, null)).toBeNull();
+    });
+  });
+
+  describe("resolveSwipeAction", () => {
+    it("returns null when the movement is below the threshold", () => {
+      expect(resolveSwipeAction(10, 10, 50)).toBeNull();
+    });
+
+    it("resolves a leftward swipe to next", () => {
+      expect(resolveSwipeAction(-80, 0, 50)).toBe("next");
+    });
+
+    it("resolves a rightward swipe to prev", () => {
+      expect(resolveSwipeAction(80, 0, 50)).toBe("prev");
+    });
+
+    it("resolves an upward swipe to open", () => {
+      expect(resolveSwipeAction(0, -80, 50)).toBe("open");
+    });
+
+    it("returns null for a downward swipe", () => {
+      expect(resolveSwipeAction(0, 80, 50)).toBeNull();
+    });
+
+    it("prefers the dominant axis when both exceed the threshold", () => {
+      expect(resolveSwipeAction(-90, 60, 50)).toBe("next");
+      expect(resolveSwipeAction(60, -90, 50)).toBe("open");
+    });
+  });
+});

--- a/src/services/cardDeck.ts
+++ b/src/services/cardDeck.ts
@@ -1,0 +1,64 @@
+export type DeckKey = "tricity" | "nearby";
+
+export type SwipeAction = "next" | "prev" | "open" | null;
+
+/**
+ * Keeps an index within the bounds of a deck of the given length.
+ * A zero-length deck always resolves to index 0.
+ */
+export function clampIndex(index: number, length: number): number {
+  if (length <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(index, 0), length - 1);
+}
+
+/**
+ * Finds which deck (and index within it) a card with the given slug lives
+ * in. Used to restore a shared/bookmarked `?route=<slug>` URL to the right
+ * deck + card on load, without the caller needing to know deck membership.
+ */
+export function locateCardBySlug(
+  decks: Record<DeckKey, { slug: string }[]>,
+  slug: string | null,
+): { deckKey: DeckKey; index: number } | null {
+  if (!slug) {
+    return null;
+  }
+
+  for (const deckKey of Object.keys(decks) as DeckKey[]) {
+    const index = decks[deckKey].findIndex((card) => card.slug === slug);
+
+    if (index !== -1) {
+      return { deckKey, index };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Turns a pointer drag delta into a deck action. The dominant axis wins:
+ * a mostly-horizontal drag pages the deck, a mostly-vertical upward drag
+ * opens the route detail page. Movement below the threshold is treated as
+ * a tap/no-op rather than a swipe.
+ */
+export function resolveSwipeAction(
+  deltaX: number,
+  deltaY: number,
+  threshold: number,
+): SwipeAction {
+  const absX = Math.abs(deltaX);
+  const absY = Math.abs(deltaY);
+
+  if (absX < threshold && absY < threshold) {
+    return null;
+  }
+
+  if (absY > absX) {
+    return deltaY < 0 ? "open" : null;
+  }
+
+  return deltaX < 0 ? "next" : "prev";
+}


### PR DESCRIPTION
## What

Implements the design resolved in [`.scratch/new-ui-prototypes/issues/04-swipeable-card-deck.md`](../blob/main/.scratch/new-ui-prototypes/issues/04-swipeable-card-deck.md): a new, additive `/discover` page that presents routes as a one-full-screen-card-at-a-time swipeable deck, instead of the existing list/grid.

- **`src/pages/discover.astro`** — new page, additive (`/list` and `/nearby` are untouched). Builds two decks of `DeckCard`s (Tricity / Nearby, mirroring the existing `tricity` boolean split) from the same content collections and `enhance`/`getLineStringFeature` pipeline the list pages already use.
- **`src/components/ui/CardDeck/CardDeck.tsx`** — `client:load` Preact island. Full-bleed preview photo, bottom gradient scrim, title + 2×2 stat tiles, truncated description, explicit "View route →" button (reuses the shared `Button` component).
- **`src/services/cardDeck.ts`** — pure, unit-tested deck logic: index clamping, slug→deck/index lookup (for restoring a shared `?route=<slug>` URL), and swipe-gesture resolution.

**Interaction model**: swipe left/right (native Pointer Events, no new gesture library) or `←`/`→` keys to page; swipe up or the "View route →" button opens the route detail page; desktop gets chevron buttons at the card edges. The current card is synced to `?route=<slug>` via `history.pushState`, including on browser Back/Forward (`popstate`), so a card is shareable/bookmarkable.

## Explicitly unchanged

Content collections, data shape, and `routes/[route].astro` itself — this is purely a new browsing surface built from existing data.

## Flagged tradeoffs (from the spec, plus one implementation-time one)

- **Discoverability**: a one-card-at-a-time view is worse than a list for "how many routes are there, which one do I want" scanning. This page is additive, not a replacement for `/list`.
- **Chevron icons**: the spec named `mdi:chevron-left`/`chevron-right` via `astro-icon`, but `astro-icon`'s `<Icon>` is an Astro-only component and can't be used inside a Preact island in this codebase (confirmed: no existing `.tsx` uses it). Used a small inline SVG chevron instead — visually equivalent, but a deviation worth knowing about if this prototype gets promoted.

## Verification

- `pnpm vitest run` — 39/39 passing (14 new, for `cardDeck.ts`)
- `pnpm astro check` — 0 errors, 0 warnings
- `pnpm astro build` — builds cleanly, `/discover` present in output
- Self-reviewed via `/code-review` (Standards + Spec axes); addressed the back-button/`popstate` gap and the hand-rolled-button-CSS duplication it surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)