### PR TITLE
Prototype: dark "outdoor gear app" visual skin (issue 06)

### DIFF
--- a/src/atoms/theme.test.ts
+++ b/src/atoms/theme.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveInitialTheme } from "./theme";
+
+describe("resolveInitialTheme", () => {
+  it("uses the stored preference when it is a valid theme", () => {
+    expect(resolveInitialTheme({ stored: "dark", prefersDark: false })).toBe(
+      "dark",
+    );
+    expect(resolveInitialTheme({ stored: "light", prefersDark: true })).toBe(
+      "light",
+    );
+  });
+
+  it("falls back to the OS preference when nothing is stored", () => {
+    expect(resolveInitialTheme({ stored: null, prefersDark: true })).toBe(
+      "dark",
+    );
+    expect(resolveInitialTheme({ stored: null, prefersDark: false })).toBe(
+      "light",
+    );
+  });
+
+  it("falls back to the OS preference when the stored value is garbage", () => {
+    expect(resolveInitialTheme({ stored: "banana", prefersDark: true })).toBe(
+      "dark",
+    );
+  });
+});

--- a/src/atoms/theme.ts
+++ b/src/atoms/theme.ts
@@ -1,0 +1,74 @@
+import { atom } from "nanostores";
+
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+const DARK_CLASS = "cc--darkmode"; // toggles vanilla-cookieconsent's dark theme
+
+export const $theme = atom<Theme>("light");
+
+/**
+ * Pure decision of which theme a page load should start in: an explicit
+ * stored choice always wins, otherwise fall back to the OS preference.
+ * Kept separate from the DOM/localStorage side effects below so it can be
+ * unit tested without a browser.
+ */
+export function resolveInitialTheme({
+  stored,
+  prefersDark,
+}: {
+  stored: string | null;
+  prefersDark: boolean;
+}): Theme {
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+
+  return prefersDark ? "dark" : "light";
+}
+
+function applyThemeToDocument(theme: Theme) {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.classList.toggle(DARK_CLASS, theme === "dark");
+}
+
+/**
+ * Sync the atom with whatever the inline head script already painted onto
+ * <html>, then keep localStorage and the DOM in sync with future changes.
+ * Call once, client-side, from the theme toggle island.
+ */
+export function initTheme() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  $theme.set(getCurrentTheme());
+
+  $theme.listen((theme) => {
+    applyThemeToDocument(theme);
+
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // localStorage can be unavailable (private mode, disabled storage) -
+      // the theme still works for the current page load, it just won't
+      // persist across visits.
+    }
+  });
+}
+
+export function toggleTheme() {
+  $theme.set($theme.get() === "dark" ? "light" : "dark");
+}
+
+export function setTheme(theme: Theme) {
+  $theme.set(theme);
+}
+
+export function getCurrentTheme(): Theme {
+  if (typeof document === "undefined") {
+    return "light";
+  }
+
+  return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+}

--- a/src/components/ui/ActivitiesList/GroupHeader/GroupHeader.astro
+++ b/src/components/ui/ActivitiesList/GroupHeader/GroupHeader.astro
@@ -9,7 +9,7 @@ const { title, description } =
   content[property][value as keyof (typeof content)[typeof property]];
 ---
 
-<h2 class="text-2xl mb-3">{title}</h2>
+<h2 class="text-2xl mb-3 dark:font-semibold">{title}</h2>
 {
   (Array.isArray(description) ? description : [description]).map(
     (paragraph) => <p class="text-lg my-2">{paragraph}</p>,

--- a/src/components/ui/Admonition.astro
+++ b/src/components/ui/Admonition.astro
@@ -23,25 +23,25 @@ const config = {
   warning: {
     iconPath: `<path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
     color: "border-amber-500",
-    titleColor: "text-amber-800",
+    titleColor: "text-amber-800 dark:text-amber-300",
     iconColor: "text-amber-500",
   },
   danger: {
     iconPath: `<path d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
     color: "border-red-500",
-    titleColor: "text-red-800",
+    titleColor: "text-red-800 dark:text-red-300",
     iconColor: "text-red-500",
   },
   success: {
     iconPath: `<path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
     color: "border-green-500",
-    titleColor: "text-green-800",
+    titleColor: "text-green-800 dark:text-green-300",
     iconColor: "text-green-500",
   },
   note: {
     iconPath: `<path d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
     color: "border-purple-500",
-    titleColor: "text-purple-800",
+    titleColor: "text-purple-800 dark:text-purple-300",
     iconColor: "text-purple-500",
   },
 };
@@ -50,11 +50,11 @@ const config = {
 const { iconPath, color, titleColor, iconColor } = config[type] || config.info;
 ---
 
-<div class={`${color} bg-slate-50 border-l-4 p-4 mb-4`}>
+<div class={`${color} bg-surface-muted border-l-4 p-4 mb-4`}>
   <div class="flex flex-col gap-2">
     {
       title && (
-        <h4 class={`font-medium mb-1 flex items-center ${titleColor}`}>
+        <h4 class={`font-medium dark:font-semibold mb-1 flex items-center ${titleColor}`}>
           {icon && (
             <div class={`mr-2 flex-shrink-0 ${iconColor}`}>
               <svg
@@ -70,7 +70,7 @@ const { iconPath, color, titleColor, iconColor } = config[type] || config.info;
         </h4>
       )
     }
-    <div class="text-md text-slate-800">
+    <div class="text-md text-ink">
       <slot />
     </div>
   </div>

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -4,7 +4,7 @@ const classNames = {
   primary:
     "select-none rounded-lg bg-green-500 py-3 px-6 text-center align-middle font-sans text-xs font-bold uppercase text-white shadow-md shadow-green-900/10 transition-all hover:shadow-lg hover:shadow-green-900/20 focus:opacity-[0.85] focus:shadow-none active:opacity-[0.85] active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none",
   neutral:
-    "select-none rounded-lg border border-gray-900 py-3 px-6 text-center align-middle font-sans text-xs font-bold uppercase text-gray-900 transition-all hover:opacity-75 focus:ring-3 focus:ring-gray-300 active:opacity-[0.85] disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none",
+    "select-none rounded-lg border border-ink py-3 px-6 text-center align-middle font-sans text-xs font-bold uppercase text-ink transition-all hover:opacity-75 focus:ring-3 focus:ring-ink-muted active:opacity-[0.85] disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none",
 };
 export const Button = ({
   children,

--- a/src/components/ui/ElevationChart/ElevationChart.tsx
+++ b/src/components/ui/ElevationChart/ElevationChart.tsx
@@ -59,8 +59,8 @@ export const ElevationChart = ({
       preserveAspectRatio="none"
     >
       <polyline
-        fill="#e2e8f0"
-        stroke="#94a3b8"
+        fill="var(--chart-fill)"
+        stroke="var(--chart-stroke)"
         strokeWidth="1"
         points={chartPoints.join("\n")}
       />
@@ -70,7 +70,7 @@ export const ElevationChart = ({
             cx={toChartX(highlightPoint[1])}
             cy={toChartY(max - highlightPoint[0])}
             fill="#64A3DB"
-            stroke="#000000"
+            stroke="var(--chart-highlight)"
             r="3"
           />
           <line
@@ -78,7 +78,7 @@ export const ElevationChart = ({
             y1={toChartY(max - highlightPoint[0]) + 3}
             x2={toChartX(highlightPoint[1])}
             y2={toChartY(max)}
-            stroke="#000000"
+            stroke="var(--chart-highlight)"
           />
         </>
       )}

--- a/src/components/ui/FullElevationChart/FullElevationChart.tsx
+++ b/src/components/ui/FullElevationChart/FullElevationChart.tsx
@@ -77,11 +77,11 @@ export const FullElevationChart = ({
       onTouchEnd={handleMouseLeave}
     >
       <div className="flex flex-col justify-between items-end pr-2">
-        <span className="text-slate-500 -mt-3">{max}m</span>
-        <span className="text-slate-500 -mb-3">{min}m</span>
+        <span className="text-ink-muted -mt-3">{max}m</span>
+        <span className="text-ink-muted -mb-3">{min}m</span>
       </div>
 
-      <div className="w-full h-full px-2 relative border-t border-b border-slate-300 border-solid">
+      <div className="w-full h-full px-2 relative border-t border-b border-line border-solid">
         <div ref={chartRef} className="relative">
           <ConnectedElevationChart points={points} height={height} />
         </div>

--- a/src/components/ui/Hero.astro
+++ b/src/components/ui/Hero.astro
@@ -3,7 +3,7 @@ const { title, description } = Astro.props;
 import Deco from "../../assets/deco.svg";
 ---
 
-<div class="bg-linear-45 from-green-700 via-green-600 to-green-700">
+<div class="bg-linear-45 from-green-700 via-green-600 to-green-700 dark:from-green-900 dark:via-green-800 dark:to-green-900">
   <div
     class="max-w-(--breakpoint-xl) mx-auto relative px-4 lg:px-0 py-12 lg:py-24 flex flex-col lg:flex-row items-center gap-12"
   >

--- a/src/components/ui/HomeMap/HomeMap.tsx
+++ b/src/components/ui/HomeMap/HomeMap.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState, useRef } from "preact/hooks";
 import maplibregl, { type LngLatLike } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { style } from "./mapStyle";
+import { getMapStyle, subscribeMapTheme } from "./getMapStyle";
+import { getCurrentTheme } from "../../../atoms/theme";
 import { getBounds } from "../../../services/getBounds";
 import { mToKm } from "../../../services/mToKm";
 import { ElevationChart } from "../ElevationChart/ElevationChart";
@@ -22,7 +23,7 @@ export const HomeMap = ({ routes }: { routes: GeoJSON.FeatureCollection }) => {
 
     const map = new maplibregl.Map({
       container: mapRef.current,
-      style,
+      style: getMapStyle(getCurrentTheme()),
       zoom: 10,
       minZoom: 9,
       maxZoom: 15,
@@ -30,6 +31,8 @@ export const HomeMap = ({ routes }: { routes: GeoJSON.FeatureCollection }) => {
 
     map.dragRotate.disable();
     map.touchZoomRotate.disableRotation();
+
+    const unsubscribeTheme = subscribeMapTheme(map);
 
     map.on("load", async () => {
       const coordinates = routes.features.reduce(
@@ -200,6 +203,10 @@ export const HomeMap = ({ routes }: { routes: GeoJSON.FeatureCollection }) => {
         tooltip.remove();
       });
     });
+
+    return () => {
+      unsubscribeTheme();
+    };
   }, []);
 
   const handleCloseSelection = () => {
@@ -211,7 +218,7 @@ export const HomeMap = ({ routes }: { routes: GeoJSON.FeatureCollection }) => {
       {selectedFeature && selectedFeature.properties && (
         <div
           id="sidebar"
-          className="absolute left-5 w-72 bottom-10 z-10 bg-slate-100 border-t-4 border-green-500"
+          className="absolute left-5 w-72 bottom-10 z-10 bg-surface border-t-4 border-accent"
         >
           <div class="flex flex-col px-4 py-3 pr-8">
             <h3 class="text-2xl">{selectedFeature.properties.name}</h3>

--- a/src/components/ui/HomeMap/getMapStyle.ts
+++ b/src/components/ui/HomeMap/getMapStyle.ts
@@ -1,0 +1,23 @@
+import type { Map as MaplibreMap } from "maplibre-gl";
+import { $theme, type Theme } from "../../../atoms/theme";
+import { style as lightStyle, glyphs } from "./mapStyle";
+import { style as darkStyle } from "./mapStyle.dark";
+
+export function getMapStyle(theme: Theme) {
+  return theme === "dark" ? darkStyle : lightStyle;
+}
+
+/**
+ * Keep a live MapLibre instance's basemap in sync with the theme toggle -
+ * the vector/raster style bakes in its own water/land/road colors, so
+ * flipping dark mode needs a real setStyle rather than a CSS filter over
+ * the canvas. Shared by every map that mounts client-side (HomeMap,
+ * createMap); returns an unsubscribe function for the caller's cleanup.
+ */
+export function subscribeMapTheme(map: MaplibreMap) {
+  return $theme.listen((theme) => {
+    map.setStyle(getMapStyle(theme));
+  });
+}
+
+export { glyphs };

--- a/src/components/ui/HomeMap/mapStyle.dark.ts
+++ b/src/components/ui/HomeMap/mapStyle.dark.ts
@@ -1,0 +1,45 @@
+// Dark counterpart to ./mapStyle.ts for the dark "outdoor gear app" skin
+// prototype (issue 06). MapLibre styles bake their own water/land/road
+// colors into the style definition, so a page-level CSS filter over the
+// canvas isn't enough - this needs a real second style, selected at mount
+// time by the same theme state as the rest of the page (see getMapStyle.ts).
+export const style =
+  import.meta.env.PUBLIC_ASTRO_USE_MAPTILER_MAP_STYLE === "true"
+    ? // MapTiler's own dark basemap in their standard style catalog, reusing
+      // the same key as the light style. NOTE: this key is domain-restricted
+      // so it couldn't be verified against the live style endpoint from this
+      // sandbox - confirm the "dataviz-dark" style id resolves for this key
+      // before treating this as production-ready.
+      "https://api.maptiler.com/maps/dataviz-dark/style.json?key=bHa0L2mKhjZqOJctPuVf"
+    : // The light fallback (mapStyle.ts) is a single raster OSM tile layer,
+      // not a vector style with separate land/water layers, so there's
+      // nothing to invert the luminance of. The real dark counterpart here
+      // is swapping to CARTO's dark raster tile server instead - a
+      // different tile source with its own baked-in dark colors, which is
+      // what actually matters (not a CSS filter over the light tiles).
+      {
+        version: 8 as const,
+        sources: {
+          "carto-dark": {
+            type: "raster" as const,
+            tiles: [
+              "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+              "https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+              "https://c.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+              "https://d.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+            ],
+            tileSize: 256,
+            attribution: "&copy; OpenStreetMap Contributors &copy; CARTO",
+            maxzoom: 19,
+          },
+        },
+        layers: [
+          {
+            id: "carto-dark" as const,
+            type: "raster" as const,
+            source: "carto-dark" as const,
+          },
+        ],
+      };
+
+export { glyphs } from "./mapStyle";

--- a/src/components/ui/ListCardItem.astro
+++ b/src/components/ui/ListCardItem.astro
@@ -7,10 +7,10 @@ const securityProps = link.startsWith("http")
 ---
 
 <li
-  class="my-4 border-b border-solid border-slate-200 last:border-0 w-full group"
+  class="my-4 border-b border-solid border-line last:border-0 w-full group"
 >
   <a class="grid grid-cols-[80px_1fr] py-4" href={link} {...securityProps}>
-    <div class="row-span-1 sm:row-span-2">
+    <div class="row-span-1 sm:row-span-2 dark:ring-1 dark:ring-white/10 dark:rounded-sm">
       <slot name="image" />
     </div>
 
@@ -21,7 +21,7 @@ const securityProps = link.startsWith("http")
 
       {
         Astro.slots.has("description") && (
-          <div class="text-l text-slate-500">
+          <div class="text-l text-ink-muted">
             <slot name="description" />
           </div>
         )

--- a/src/components/ui/ListCardItem/Activity.astro
+++ b/src/components/ui/ListCardItem/Activity.astro
@@ -20,18 +20,18 @@ const { link, icon, image, name, description } = Astro.props;
     ) : (
       <div
         slot="image"
-        class="bg-green-200 w-16 h-16 flex items-center justify-center group-hover:bg-black group-hover:text-green-200"
+        class="bg-green-200 text-slate-900 w-16 h-16 flex items-center justify-center group-hover:bg-black group-hover:text-green-200"
       >
         <Icon name={icon} class="w-12 h-12" />
       </div>
     )
   }
 
-  <span class="group-hover:text-green-600" slot="title">
+  <span class="group-hover:text-accent-strong" slot="title">
     {name}
   </span>
 
-  <span class="group-hover:text-green-600" slot="description">
+  <span class="group-hover:text-accent-strong" slot="description">
     {description}
   </span>
 </ListCardItem>

--- a/src/components/ui/ListCardItem/Food.astro
+++ b/src/components/ui/ListCardItem/Food.astro
@@ -8,12 +8,12 @@ const { link, icon, name, location } = Astro.props;
 <ListCardItem bordered link={link}>
   <div
     slot="image"
-    class="bg-green-200 w-16 h-16 shrink-0 flex items-center justify-center group-hover:bg-black group-hover:text-green-200"
+    class="bg-green-200 text-slate-900 w-16 h-16 shrink-0 flex items-center justify-center group-hover:bg-black group-hover:text-green-200"
   >
     <Icon name={icon} class="w-12 h-12" />
   </div>
 
-  <span class="group-hover:text-green-600" slot="title">
+  <span class="group-hover:text-accent-strong" slot="title">
     {name}
   </span>
 

--- a/src/components/ui/ListCardItem/Route.astro
+++ b/src/components/ui/ListCardItem/Route.astro
@@ -24,14 +24,14 @@ const { route, properties } = Astro.props;
       />
     )
   }
-  <span class="flex gap-1 group-hover:text-green-600" slot="title">
-    <Icon name="mdi:location-on" class="text-green-500" />
+  <span class="flex gap-1 group-hover:text-accent-strong" slot="title">
+    <Icon name="mdi:location-on" class="text-accent" />
     {route.data.title}
   </span>
 
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-lg" slot="attributes">
     <TrailAttribute>
-      <Icon name="mdi:hiking" class="w-5 h-5 text-slate-500" slot="icon" />
+      <Icon name="mdi:hiking" class="w-5 h-5 text-ink-muted" slot="icon" />
 
       <TrailAttributeValue
         value={`${mToKm(properties.distance).toFixed(2)}km`}
@@ -40,7 +40,7 @@ const { route, properties } = Astro.props;
     </TrailAttribute>
 
     <TrailAttribute>
-      <Icon name="mdi:clock-fast" class="w-5 h-5 text-slate-500" slot="icon" />
+      <Icon name="mdi:clock-fast" class="w-5 h-5 text-ink-muted" slot="icon" />
 
       <TrailAttributeValue value={formatTime(properties.estimatedTime)} />
       <TrailAttributeName value="Time" />
@@ -49,7 +49,7 @@ const { route, properties } = Astro.props;
     <TrailAttribute>
       <Icon
         name="mdi:arrow-top-right-thin"
-        class="w-5 h-5 text-slate-500"
+        class="w-5 h-5 text-ink-muted"
         slot="icon"
       />
 
@@ -60,7 +60,7 @@ const { route, properties } = Astro.props;
     <TrailAttribute>
       <Icon
         name="mdi:arrow-bottom-right-thin"
-        class="w-5 h-5 text-slate-500"
+        class="w-5 h-5 text-ink-muted"
         slot="icon"
       />
 

--- a/src/components/ui/ListCardItemAttribute.astro
+++ b/src/components/ui/ListCardItemAttribute.astro
@@ -8,7 +8,7 @@ const { icon, name, value } = Astro.props;
 ---
 
 <TrailAttribute>
-  <Icon name={icon} class="w-5 h-5 text-slate-500" slot="icon" />
+  <Icon name={icon} class="w-5 h-5 text-ink-muted" slot="icon" />
 
   <TrailAttributeValue value={value} />
   <TrailAttributeName value={name} />

--- a/src/components/ui/NavLink.astro
+++ b/src/components/ui/NavLink.astro
@@ -12,8 +12,8 @@ const isActive = matches ? matches(pathname) : defaultMatch;
   class:list={[
     "px-4 py-2 w-full lg:w-auto relative lg:rounded-xl",
     {
-      "underline decoration-green-400 hover:decoration-green-600": isActive,
-      "text-slate-600 hover:underline": !isActive,
+      "underline decoration-accent hover:decoration-accent-strong": isActive,
+      "text-ink-muted hover:underline": !isActive,
     },
   ]}
 >

--- a/src/components/ui/RouteMapLegend.astro
+++ b/src/components/ui/RouteMapLegend.astro
@@ -14,7 +14,7 @@ const loopIcon = generateLoopMarkerSVG(16, MAP_MARKER_COLOR); // red color for l
 ---
 
 <div class="max-w-(--breakpoint-xl) mx-auto relative px-2 lg:px-0 my-4">
-  <h3 class="text-lg font-medium mb-3">Map Legend</h3>
+  <h3 class="text-lg font-medium dark:font-semibold mb-3">Map Legend</h3>
   <ul class="flex flex-wrap gap-x-6 gap-y-2">
     <li class="flex items-center gap-3">
       <img src={startIcon} alt="Start marker" class="w-4 h-4" />

--- a/src/components/ui/Tabs/Tab.astro
+++ b/src/components/ui/Tabs/Tab.astro
@@ -4,10 +4,10 @@ const { href, active } = Astro.props;
 
 <a
   class:list={[
-    "px-6 sm:px-12 py-2 sm:py-3 text-sm font-medium inline-flex items-center gap-2 relative border-t-2 border-l last:border-r border-l-gray-300 last:border-r-gray-300 whitespace-nowrap snap-start",
+    "px-6 sm:px-12 py-2 sm:py-3 text-sm font-medium inline-flex items-center gap-2 relative border-t-2 border-l last:border-r border-l-line last:border-r-line whitespace-nowrap snap-start",
     {
-      "text-green-600 border-t-green-600": active,
-      "text-gray-900 bg-zinc-100 border-t-transparent": !active,
+      "text-accent border-t-accent": active,
+      "text-ink bg-surface-muted border-t-transparent": !active,
     },
   ]}
   href={href}

--- a/src/components/ui/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from "preact/hooks";
+import { useStore } from "@nanostores/preact";
+import { $theme, initTheme, toggleTheme } from "../../../atoms/theme";
+
+export const ThemeToggle = () => {
+  const theme = useStore($theme);
+
+  useEffect(() => {
+    initTheme();
+  }, []);
+
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      aria-pressed={isDark}
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="cursor-pointer rounded-full p-2 text-ink-muted hover:text-ink hover:bg-surface-muted transition-colors"
+    >
+      {isDark ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-5 h-5"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-5 h-5"
+        >
+          <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/ui/Timeline/TimelineConnector.astro
+++ b/src/components/ui/Timeline/TimelineConnector.astro
@@ -1,1 +1,1 @@
-<div class="w-0.5 bg-gray-400 flex-grow"></div>
+<div class="w-0.5 bg-line flex-grow"></div>

--- a/src/components/ui/Timeline/TimelineContentLabel.astro
+++ b/src/components/ui/Timeline/TimelineContentLabel.astro
@@ -1,6 +1,6 @@
 <div class="flex items-center gap-1 -ml-4 flex-1">
-  <div class="h-[1px] w-10 bg-gray-400"></div>
-  <div class="text-gray-600 text-xs">
+  <div class="h-[1px] w-10 bg-line"></div>
+  <div class="text-ink-muted text-xs">
     <slot />
   </div>
 </div>

--- a/src/components/ui/Timeline/TimelineDot.astro
+++ b/src/components/ui/Timeline/TimelineDot.astro
@@ -5,8 +5,8 @@ const { variant = "regular" } = Astro.props;
 {
   variant == "regular" && (
     <div class="flex flex-col flex-0 items-center relative">
-      <div class="w-0.5 bg-gray-400 flex-grow" />
-      <div class="p-1 my-3 rounded-full border-2 border-green-600 bg-green-600 absolute" />
+      <div class="w-0.5 bg-line flex-grow" />
+      <div class="p-1 my-3 rounded-full border-2 border-accent bg-accent absolute" />
     </div>
   )
 }
@@ -14,8 +14,8 @@ const { variant = "regular" } = Astro.props;
 {
   variant == "minor" && (
     <div class="flex flex-col flex-0 items-center relative">
-      <div class="w-0.5 bg-gray-400 flex-grow" />
-      <div class="p-0.5 my-3.5 rounded-full border-2 border-gray-400 bg-white absolute" />
+      <div class="w-0.5 bg-line flex-grow" />
+      <div class="p-0.5 my-3.5 rounded-full border-2 border-line bg-surface absolute" />
     </div>
   )
 }

--- a/src/components/ui/Timeline/TimelineOppositeContentSecondary.astro
+++ b/src/components/ui/Timeline/TimelineOppositeContentSecondary.astro
@@ -1,3 +1,3 @@
-<div class="max-w-72 text-right py-1.5 text-sm text-gray-600">
+<div class="max-w-72 text-right py-1.5 text-sm text-ink-muted">
   <slot />
 </div>

--- a/src/components/ui/TrailAttributeName/TrailAttributeName.tsx
+++ b/src/components/ui/TrailAttributeName/TrailAttributeName.tsx
@@ -1,3 +1,3 @@
 export const TrailAttributeName = ({ value }: { value: string }) => {
-  return <span className="text-xs lg:text-sm text-slate-500">{value}</span>;
+  return <span className="text-xs lg:text-sm text-ink-muted">{value}</span>;
 };

--- a/src/components/ui/TrailAttributeValue/TrailAttributeValue.tsx
+++ b/src/components/ui/TrailAttributeValue/TrailAttributeValue.tsx
@@ -1,3 +1,3 @@
 export const TrailAttributeValue = ({ value }: { value: string }) => {
-  return <span className="text-lg lg:text-xl text-slate-500">{value}</span>;
+  return <span className="text-lg lg:text-xl text-ink-muted">{value}</span>;
 };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,6 +10,7 @@ import SidebarSwitch from "../components/ui/SidebarSwitch/SidebarSwitch.tsx";
 import NavLink from "../components/ui/NavLink.astro";
 import Analytics from "../components/ui/Analytics.astro";
 import CookieConsent from "../components/ui/CookieConsent/CookieConsent.astro";
+import ThemeToggle from "../components/ui/ThemeToggle/ThemeToggle.tsx";
 import logo from "../assets/logo.png";
 
 const pathname = new URL(Astro.request.url).pathname;
@@ -33,6 +34,28 @@ const { title, description } = Astro.props;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <script is:inline>
+      // Prototype for issue 06 (dark outdoor-gear skin): set data-theme
+      // before first paint so there's no flash of the wrong theme. Mirrors
+      // the pure logic in src/atoms/theme.ts#resolveInitialTheme, but has
+      // to be duplicated here as inline vanilla JS since ES module imports
+      // don't run early enough to beat the first paint.
+      (function () {
+        try {
+          var stored = localStorage.getItem("theme");
+          var theme =
+            stored === "light" || stored === "dark"
+              ? stored
+              : window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+          document.documentElement.dataset.theme = theme;
+          if (theme === "dark") {
+            document.documentElement.classList.add("cc--darkmode");
+          }
+        } catch (e) {}
+      })();
+    </script>
     <meta
       name="description"
       content={description ??
@@ -71,7 +94,7 @@ const { title, description } = Astro.props;
 
     <main>
       <nav
-        class="flex relative justify-center lg:justify-start bg-slate-50 py-2 sm:py-4 px-2"
+        class="flex relative justify-center lg:justify-start items-center bg-surface-muted py-2 sm:py-4 px-2"
       >
         <SidebarSwitch
           className="lg:hidden absolute left-3 top-2 cursor-pointer"
@@ -90,7 +113,7 @@ const { title, description } = Astro.props;
           />
         </a>
 
-        <div id="sidebar" class="sidebar bg-slate-50">
+        <div id="sidebar" class="sidebar bg-surface-muted">
           <div
             class="flex gap-2 items-center flex-col lg:flex-row lg:ml-4 h-full pt-2 lg:pt-0"
           >
@@ -109,6 +132,10 @@ const { title, description } = Astro.props;
             <NavLink href="/blog/the-best-hiking-trails-near-gdansk/">Articles</NavLink>
           </div>
         </div>
+
+        <div class="absolute right-3 top-1/2 -translate-y-1/2 lg:static lg:ml-auto lg:translate-y-0">
+          <ThemeToggle client:load />
+        </div>
       </nav>
 
       <div class="">
@@ -119,14 +146,14 @@ const { title, description } = Astro.props;
       </div>
     </main>
 
-    <footer class="px-2 lg:px-0 border-t border-solid border-slate-200">
+    <footer class="px-2 lg:px-0 border-t border-solid border-line">
       <div class="max-w-(--breakpoint-xl) mx-auto flex py-8 gap-8">
         <div>Tricity Hiking, {new Date().getFullYear()}</div>
         <nav>
           <ul class="list-none flex gap-4">
             <li>
               <a
-                class="text-slate-600 hover:underline"
+                class="text-ink-muted hover:underline"
                 href="https://github.com/ertrzyiks/tricity-hiking"
                 target="_blank"
                 rel="noopener">Github</a
@@ -134,7 +161,7 @@ const { title, description } = Astro.props;
             </li>
             <li>
               <button
-                class="text-slate-600 hover:underline cursor-pointer"
+                class="text-ink-muted hover:underline cursor-pointer"
                 type="button"
                 data-cc="show-preferencesModal"
                 >Cookies
@@ -142,7 +169,7 @@ const { title, description } = Astro.props;
             </li>
             <li>
               <a
-                class="text-slate-600 hover:underline"
+                class="text-ink-muted hover:underline"
                 href="https://byd5xay149t.typeform.com/to/R0pgudVy"
                 target="_blank"
                 rel="noopener">Contact</a
@@ -168,7 +195,11 @@ const { title, description } = Astro.props;
   }
   html {
     font-family: "Fira Sans", sans-serif;
-    background: #f8fafc;
+    background: var(--color-canvas);
+    color: var(--color-ink);
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
   }
   code {
     font-family:

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -48,7 +48,7 @@ const publishedDate = entry.data.publishDate.toLocaleDateString("en-US", {
     <article>
       <header class="mb-8">
         <h1 class="text-4xl font-bold mb-4">{entry.data.title}</h1>
-        <div class="flex flex-wrap gap-4 text-sm text-slate-600 mb-4">
+        <div class="flex flex-wrap gap-4 text-sm text-ink-muted mb-4">
           <time class="flex items-center gap-1">
             <svg
               class="w-4 h-4"
@@ -90,7 +90,7 @@ const publishedDate = entry.data.publishDate.toLocaleDateString("en-US", {
           entry.data.tags && entry.data.tags.length > 0 && (
             <div class="flex flex-wrap gap-2">
               {entry.data.tags.map((tag) => (
-                <span class="px-3 py-1 text-xs bg-green-100 text-green-800 rounded-full">
+                <span class="px-3 py-1 text-xs bg-green-100 text-green-800 dark:bg-accent/15 dark:text-accent rounded-full">
                   {tag}
                 </span>
               ))}
@@ -104,10 +104,10 @@ const publishedDate = entry.data.publishDate.toLocaleDateString("en-US", {
       </div>
     </article>
 
-    <nav class="mt-12 pt-8 border-t border-slate-200">
+    <nav class="mt-12 pt-8 border-t border-line">
       <a
         href="/"
-        class="inline-flex items-center gap-2 text-green-600 hover:text-green-800 font-medium"
+        class="inline-flex items-center gap-2 text-accent hover:text-accent-strong font-medium"
       >
         <svg
           class="w-4 h-4"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,7 @@ for (const route of featuredRoutes) {
         <TricityMap class="w-56 h-56" />
       </div>
       <div class="px-2 lg:px-0">
-        <p class="text-slate-700">
+        <p class="text-ink-muted">
           Tricity—made up of Gdańsk, Sopot, and Gdynia—is a unique region in
           northern Poland where the Baltic Sea meets the gentle hills of the
           Tricity Landscape Park. From the medieval streets of Gdańsk to the
@@ -65,38 +65,38 @@ for (const route of featuredRoutes) {
       <h2 class="text-2xl mb-8">Why?</h2>
 
       <div class="flex flex-col lg:flex-row gap-8">
-        <div class="flex-1 bg-white p-8 rounded-lg shadow-lg">
+        <div class="flex-1 bg-surface p-8 rounded-lg shadow-lg dark:shadow-black/40">
           <div class="flex items-center gap-2">
             <Icon name="mdi:forest" class="w-6 h-6" />
             <h3 class="text-lg font-bold">Explore Nature</h3>
           </div>
-          <p class="text-slate-700 mt-4">
+          <p class="text-ink-muted mt-4">
             Almost 200,000 square meters of landscape protected area. The
             terrain is pleasantly varied, offering forest trails, occasional
             viewpoints, and a refreshing break from flat cityscapes.
           </p>
         </div>
 
-        <div class="flex-1 bg-white p-8 rounded-lg shadow-lg">
+        <div class="flex-1 bg-surface p-8 rounded-lg shadow-lg dark:shadow-black/40">
           <div class="flex items-center gap-2">
             <Icon name="mdi:museum" class="w-6 h-6" />
             <h3 class="text-lg font-bold flex items-center gap-2">
               Unearth a Rich History
             </h3>
           </div>
-          <p class="text-slate-700 mt-4">
+          <p class="text-ink-muted mt-4">
             With over 1,000 years of history in Gdańsk, the charming seaside
             town of Sopot, which has attracted visitors since the 19th century,
             and the rise of Gdynia in the 20th century, traces of history are
             everywhere.
           </p>
         </div>
-        <div class="flex-1 bg-white p-8 rounded-lg shadow-lg">
+        <div class="flex-1 bg-surface p-8 rounded-lg shadow-lg dark:shadow-black/40">
           <div class="flex items-center gap-2">
             <Icon name="mdi:local-restaurant" class="w-6 h-6" />
             <h3 class="text-lg font-bold">Take a Break</h3>
           </div>
-          <p class="text-slate-700 mt-4">
+          <p class="text-ink-muted mt-4">
             After a long day of hiking, you can relax in one of the many
             restaurants or cafes. Tricity offers a wide range of dining options,
             where you can unwind and enjoy the local culture.

--- a/src/pages/routes.astro
+++ b/src/pages/routes.astro
@@ -46,7 +46,7 @@ const geojson = merge(geojsonList);
 
     <div class="max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0 py-4">
       <a
-        class="px-4 py-2 rounded-md border border-solid bg-green-50 hover:bg-green-200 text-slate-900 border-green-300 inline-block"
+        class="px-4 py-2 rounded-md border border-solid bg-green-50 hover:bg-green-200 text-slate-900 border-green-300 dark:bg-accent/10 dark:hover:bg-accent/20 dark:text-accent dark:border-accent/40 inline-block"
         href="/extended/"
       >
         Include nearby routes

--- a/src/pages/routes/[route].astro
+++ b/src/pages/routes/[route].astro
@@ -79,7 +79,7 @@ if (!feature) {
                 src={entry.data.preview}
                 width="320"
                 height="320"
-                class=""
+                class="dark:ring-1 dark:ring-white/10 dark:rounded-sm"
                 alt={"Preview of the route on the map"}
                 slot="image"
               />

--- a/src/pages/routes/[route]/map.astro
+++ b/src/pages/routes/[route]/map.astro
@@ -67,7 +67,7 @@ if (!feature) {
   >
     <RouteMap client:only="preact" route={geojson.data} />
 
-    <div class="absolute bottom-0 left-0 w-96 bg-green-50">
+    <div class="absolute bottom-0 left-0 w-96 bg-surface">
       <FullElevationChart client:load points={attitudes} />
     </div>
   </div>

--- a/src/pages/transportation.astro
+++ b/src/pages/transportation.astro
@@ -32,7 +32,7 @@ const pkm = merge([pkmStops.data, pkmLine.data]);
       Plan you route and buy tickets for all public transport in Tricity using
       <strong>
         <a
-          class="hover:underline text-green-500 inline-flex items-baseline"
+          class="hover:underline text-accent inline-flex items-baseline"
           href="https://jakdojade.pl/"
           target="_blank"
           rel="noopener"
@@ -104,7 +104,7 @@ const pkm = merge([pkmStops.data, pkmLine.data]);
 
         <figure class="my-4 h-128">
           <TransportationMap data={skm} client:only="preact" />
-          <figcaption class="text-base text-slate-500 text-center my-2">
+          <figcaption class="text-base text-ink-muted text-center my-2">
             SKM train map (selected fragment)
           </figcaption>
         </figure>
@@ -132,7 +132,7 @@ const pkm = merge([pkmStops.data, pkmLine.data]);
         <figure class="my-4 h-128">
           <TransportationMap data={pkm} client:only="preact" />
 
-          <figcaption class="text-base text-slate-500 text-center my-2">
+          <figcaption class="text-base text-ink-muted text-center my-2">
             PKM train map (selected fragment)
           </figcaption>
         </figure>

--- a/src/services/createMap.ts
+++ b/src/services/createMap.ts
@@ -1,5 +1,11 @@
 import { Map, type MapOptions } from "maplibre-gl";
-import { style, glyphs } from "../components/ui/HomeMap/mapStyle";
+import {
+  getMapStyle,
+  glyphs,
+  subscribeMapTheme,
+} from "../components/ui/HomeMap/getMapStyle";
+import { getCurrentTheme } from "../atoms/theme";
+
 export const createMap = (
   container: HTMLElement,
   options: Omit<MapOptions, "container" | "style">,
@@ -7,7 +13,7 @@ export const createMap = (
 ) => {
   const map = new Map({
     container: container,
-    style,
+    style: getMapStyle(getCurrentTheme()),
     zoom: 10,
     minZoom: 9,
     maxZoom: 15,
@@ -26,7 +32,10 @@ export const createMap = (
     cleanUp = await initializer(map);
   });
 
+  const unsubscribeTheme = subscribeMapTheme(map);
+
   return () => {
+    unsubscribeTheme();
     cleanUp?.();
     map.remove();
   };

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3,6 +3,50 @@
 @theme {
   --grid-template-columns-header: 50px 1fr 50px;
   --grid-template-columns-layout: 300px 1fr;
+
+  /*
+    Dark "outdoor gear app" skin tokens (prototype for issue 06). Semantic
+    surface/text/accent colors used everywhere instead of hardcoded
+    slate/green utilities, so a single attribute flips the whole site.
+    Defaults here are the existing light palette; dark values are
+    overridden below under [data-theme="dark"].
+  */
+  --color-canvas: #f8fafc;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f8fafc;
+  --color-ink: #0f172a;
+  --color-ink-muted: #475569;
+  --color-line: #e2e8f0;
+  --color-accent: #16a34a;
+  --color-accent-strong: #15803d;
+
+  /* Raw SVG stroke/fill colors for ElevationChart, which draws attributes
+     directly rather than through Tailwind utility classes. */
+  --chart-fill: #e2e8f0;
+  --chart-stroke: #94a3b8;
+  --chart-highlight: #0f172a;
+}
+
+/*
+  Lets `dark:` utilities key off a `data-theme="dark"` attribute (set by the
+  theme toggle) instead of Tailwind's default `prefers-color-scheme`-only
+  behavior - needed because this site has a manual toggle, not just an OS
+  preference (see src/atoms/theme.ts).
+*/
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+:root[data-theme="dark"] {
+  --color-canvas: #0d1117;
+  --color-surface: #161b22;
+  --color-surface-muted: #161b22;
+  --color-ink: #e6edf3;
+  --color-ink-muted: #9198a1;
+  --color-line: #30363d;
+  --color-accent: #a3e635;
+  --color-accent-strong: #bef264;
+  --chart-fill: #21262d;
+  --chart-stroke: #6e7681;
+  --chart-highlight: #e6edf3;
 }
 
 /*
@@ -55,6 +99,6 @@
 }
 
 .simple-link {
-  @apply text-green-600;
-  @apply hover:text-green-700 hover:underline;
+  @apply text-accent;
+  @apply hover:text-accent-strong hover:underline;
 }


### PR DESCRIPTION
Prototype for [issue 06 — dark "outdoor gear app" visual skin](../blob/main/.scratch/new-ui-prototypes/issues/06-dark-outdoor-app-skin.md) (resolved spec, see `## Answer`).

## What this is

A live, toggleable dark skin applied across the existing site — same pages, navigation, and data, only the visual language changes. This is a **throwaway prototype for design review**, not a finished production PR.

## What changed

- **Design tokens** (`src/styles/base.css`): semantic `canvas`/`surface`/`ink`/`line`/`accent` custom properties with light defaults, overridden under `[data-theme="dark"]`, plus a Tailwind v4 `@custom-variant dark` keyed off that attribute (this site has no existing theme infra).
- **Palette**: `#0d1117` canvas / `#161b22` surface, lime-400 (`#a3e635`) accent replacing green-500/600 for links and active states. `MAP_MARKER_COLOR` stays as-is per spec.
- **Toggle, not dark-only**: `src/atoms/theme.ts` (nanostore atom + a pure, unit-tested `resolveInitialTheme`), an inline pre-paint `<head>` script in `Layout.astro` to avoid a flash of the wrong theme, a `ThemeToggle.tsx` island, `localStorage` persistence defaulted from `prefers-color-scheme` — justified in the spec by outdoor/daylight use.
- **A real dark MapLibre basemap** (`mapStyle.dark.ts` + `getMapStyle.ts`), selected at mount and kept live-in-sync when the toggle flips, wired into every map the user actually sees (`HomeMap`, and `RouteMap`/`TransportationMap` via `createMap.ts`). The build-time preview-image capture route (`/preview/[route]`, dev-only, used by `capture-route-preview.js`) intentionally stays light — it bakes static thumbnails once, which is exactly the risk the spec itself flags.
- **Componentwide dark-mode pass**: `ListCardItem`, `TrailAttribute*`, `Timeline` dots/connectors, `Admonition`, `Tabs`, `NavLink`, `Button`, the raw-SVG `ElevationChart`. `CookieConsent` gets vanilla-cookieconsent's built-in `cc--darkmode` class toggled alongside `data-theme` rather than a file edit.
- **Photo/map contrast risk** (flagged in the spec): a thin `dark:ring-1 dark:ring-white/10` frame on photo elements (list thumbnails, route detail preview image).

## Review

Ran `/code-review` (standards + spec sub-agents) and addressed the real findings: deduplicated the map/theme-subscription logic into `subscribeMapTheme()` (was copy-pasted in `HomeMap.tsx` and `createMap.ts`), swapped two ad-hoc `lime-950` utilities for the existing `accent` token (opacity modifiers) to match the diff's own stated convention, broadened heading-weight (`medium`→`semibold`) coverage to `RouteMapLegend`, and clarified the raster-vs-vector comment in `mapStyle.dark.ts`. `PreviewRouteMap.tsx` staying light-only is intentional (see above), not a miss.

## Try it

`pnpm dev`, then use the toggle button in the top-right of the nav. Defaults to your OS preference; persists across reloads.

## Known caveats

- The MapTiler `dataviz-dark` production style id couldn't be verified against the live key from this sandbox (key is domain-restricted) — confirm it resolves before treating the production map path as ready.
- This is prototype code per the `/prototype` skill's rules: no error-handling polish beyond what's needed to run, and it's meant to be judged/iterated on, not merged as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
