### PR TITLE
Prototype: magazine/editorial route layout (issue 07)

### DIFF
--- a/src/components/markdown/Heading2Editorial.tsx
+++ b/src/components/markdown/Heading2Editorial.tsx
@@ -1,0 +1,13 @@
+import type { ComponentChildren } from "preact";
+
+interface Props {
+  children: ComponentChildren;
+}
+
+export const Heading2Editorial = ({ children }: Props) => {
+  return (
+    <h2 className="font-display pt-8 pb-3 text-3xl font-semibold">
+      {children}
+    </h2>
+  );
+};

--- a/src/components/markdown/PullQuote.tsx
+++ b/src/components/markdown/PullQuote.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  quote: string;
+}
+
+export const PullQuote = ({ quote }: Props) => {
+  return (
+    <blockquote className="font-display my-6 border-l-4 border-green-600 pl-5 text-2xl leading-snug text-slate-800 italic lg:text-3xl">
+      {quote}
+    </blockquote>
+  );
+};

--- a/src/components/markdown/createEditorialMarkdownComponents.test.tsx
+++ b/src/components/markdown/createEditorialMarkdownComponents.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { createEditorialMarkdownComponents } from "./createEditorialMarkdownComponents";
+import { PullQuote } from "./PullQuote";
+
+describe("createEditorialMarkdownComponents", () => {
+  it("still resolves the right pull quote when the same headings are rendered a second time (Astro renders MDX content more than once per page)", () => {
+    const pullQuotes = [
+      null,
+      { sectionIndex: 1, sectionTitle: "Olivia", quote: "Quote text" },
+    ];
+    const { h2: Heading2 } = createEditorialMarkdownComponents(pullQuotes);
+
+    const renderBothHeadings = () => [
+      Heading2({ id: "starting-point", children: "Starting point" }),
+      Heading2({ id: "olivia", children: "Olivia" }),
+    ];
+
+    // First pass over the headings, e.g. Astro collecting `headings` metadata.
+    renderBothHeadings();
+    // Second pass: the actual page render, same ids in the same order.
+    const [firstHeading, secondHeading] = renderBothHeadings();
+
+    const hasPullQuote = (vnode: any) =>
+      ([] as any[])
+        .concat(vnode.props.children)
+        .some((child) => child && child.type === PullQuote);
+
+    expect(hasPullQuote(firstHeading)).toBe(false);
+    expect(hasPullQuote(secondHeading)).toBe(true);
+  });
+});

--- a/src/components/markdown/createEditorialMarkdownComponents.tsx
+++ b/src/components/markdown/createEditorialMarkdownComponents.tsx
@@ -1,0 +1,61 @@
+import type { ComponentChildren, FunctionComponent } from "preact";
+import { config } from "./index";
+import { Heading2Editorial } from "./Heading2Editorial";
+import { PullQuote } from "./PullQuote";
+import type { PullQuote as PullQuoteData } from "../../services/getPullQuotes";
+
+interface HeadingProps {
+  id?: string;
+  children: ComponentChildren;
+}
+
+/**
+ * Builds a per-page MDX component override map for the magazine/editorial
+ * route detail template: same base config as everywhere else (paragraphs,
+ * links, lists, emphasis), plus a serif h2 and, breaking the text column
+ * right after it, the pre-computed pull-quote for that section (if any).
+ *
+ * Astro renders `<Content>` more than once per page (at least once to
+ * collect `headings` metadata, once to produce the actual HTML), calling
+ * this h2 override each time with the *same* sequence of heading `id`s. A
+ * plain call-order counter would double-count and run off the end of
+ * `pullQuotes` on the second pass, so instead each `id` is mapped to a
+ * section index the first time it's seen and reused on every later call -
+ * stable across any number of render passes, in whatever order Astro
+ * chooses to run them.
+ */
+export function createEditorialMarkdownComponents(
+  pullQuotes: ReadonlyArray<PullQuoteData | null>,
+) {
+  const sectionIndexById = new Map<string, number>();
+  let nextIndex = 0;
+
+  const Heading2WithPullQuote: FunctionComponent<HeadingProps> = ({
+    id,
+    children,
+  }) => {
+    let index = id === undefined ? undefined : sectionIndexById.get(id);
+
+    if (index === undefined) {
+      index = nextIndex;
+      nextIndex += 1;
+      if (id !== undefined) {
+        sectionIndexById.set(id, index);
+      }
+    }
+
+    const pullQuote = pullQuotes[index];
+
+    return (
+      <>
+        <Heading2Editorial>{children}</Heading2Editorial>
+        {pullQuote && <PullQuote quote={pullQuote.quote} />}
+      </>
+    );
+  };
+
+  return {
+    ...config,
+    h2: Heading2WithPullQuote,
+  };
+}

--- a/src/components/ui/ListCardItem/RouteEditorial.astro
+++ b/src/components/ui/ListCardItem/RouteEditorial.astro
@@ -1,0 +1,59 @@
+---
+import { Icon } from "astro-icon/components";
+import { Image } from "astro:assets";
+import { mToKm } from "../../../services/mToKm";
+import { formatTime } from "../../../services/formatTime";
+
+const { route, properties, reverse = false } = Astro.props;
+
+const statLine = [
+  `${mToKm(properties.distance).toFixed(1)} km`,
+  formatTime(properties.estimatedTime),
+  `+${properties.totalGain.toFixed(0)}m`,
+].join(" · ");
+---
+
+<li class="group my-8 w-full border-b border-solid border-slate-200 pb-8 last:border-0 last:pb-0">
+  <a
+    href={`/routes/${route.id}/`}
+    class:list={[
+      "flex flex-col gap-6 sm:flex-row",
+      reverse && "sm:flex-row-reverse",
+    ]}
+  >
+    <div class="sm:w-2/5 sm:shrink-0">
+      {
+        route.data.preview?.src ? (
+          <Image
+            src={route.data.preview}
+            width="640"
+            height="480"
+            class="aspect-[4/3] w-full object-cover grayscale-75 transition-[filter] group-hover:grayscale-0"
+            alt="Preview of the route on the map"
+          />
+        ) : (
+          <div class="from-green-700 via-green-600 to-green-700 flex aspect-[4/3] w-full items-center justify-center bg-linear-45">
+            <Icon name="mdi:location-on" class="h-10 w-10 text-slate-100" />
+          </div>
+        )
+      }
+    </div>
+
+    <div class="flex flex-1 flex-col justify-center gap-2">
+      <span class="font-display flex items-center gap-1 text-2xl text-slate-900 group-hover:text-green-600 lg:text-3xl">
+        <Icon name="mdi:location-on" class="text-green-500" />
+        {route.data.title}
+      </span>
+
+      {
+        route.data.description && (
+          <p class="line-clamp-2 max-w-prose text-slate-500">
+            {route.data.description}
+          </p>
+        )
+      }
+
+      <span class="text-sm text-slate-500">{statLine}</span>
+    </div>
+  </a>
+</li>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -22,6 +22,10 @@ const routesCollection = defineCollection({
       featured: z.literal("homepage").optional(),
       draft: z.boolean().optional(),
       preview: image().optional(),
+      // Manual escape hatch for the magazine/editorial layout's automated
+      // pull-quote heuristic (see getPullQuotes.ts) - overrides the
+      // heuristic's picks for the 2nd, 4th, ... `##` section, in order.
+      pullQuotes: z.array(z.string()).optional(),
     }),
 });
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,6 +56,21 @@ const { title, description } = Astro.props;
         href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
       />
     </noscript>
+    <!-- Display serif used by the magazine/editorial route layout prototype
+         (issue 07) - only referenced via the `font-display` utility, so
+         pages that don't opt in are unaffected. -->
+    <link
+      rel="preload"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap"
+      onload="this.onload=null;this.rel='stylesheet';this.removeAttribute('as')"
+      as="style"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap"
+      />
+    </noscript>
 
     {urls.map((url) => <link rel="prefetch" href={url} crossorigin />)}
 

--- a/src/pages/list.astro
+++ b/src/pages/list.astro
@@ -4,7 +4,7 @@ import Layout from "../layouts/Layout.astro";
 import Homepage from "../components/ui/Homepage.astro";
 import { enhance } from "../services/enhance";
 import { getLineStringFeature } from "../services/getLineStringFeature";
-import RouteListItem from "../components/ui/ListCardItem/Route.astro";
+import RouteListItem from "../components/ui/ListCardItem/RouteEditorial.astro";
 
 const allRoutes = await getCollection("routes");
 const routes = allRoutes.filter((route) => {
@@ -34,8 +34,12 @@ for (const route of tricityRoutes) {
     <div class="max-w-(--breakpoint-xl) mx-auto relative px-2 lg:px-0">
       <ul>
         {
-          geojsonList.map(({ route, properties }) => (
-            <RouteListItem route={route} properties={properties} />
+          geojsonList.map(({ route, properties }, index) => (
+            <RouteListItem
+              route={route}
+              properties={properties}
+              reverse={index % 2 === 1}
+            />
           ))
         }
       </ul>

--- a/src/pages/nearby.astro
+++ b/src/pages/nearby.astro
@@ -4,7 +4,7 @@ import Layout from "../layouts/Layout.astro";
 import Homepage from "../components/ui/Homepage.astro";
 import { enhance } from "../services/enhance";
 import { getLineStringFeature } from "../services/getLineStringFeature";
-import RouteListItem from "../components/ui/ListCardItem/Route.astro";
+import RouteListItem from "../components/ui/ListCardItem/RouteEditorial.astro";
 
 const allRoutes = await getCollection("routes");
 const routes = allRoutes.filter((route) => {
@@ -36,8 +36,12 @@ for (const route of nearbyRoutes) {
     <div class="max-w-(--breakpoint-xl) mx-auto relative px-2 lg:px-0">
       <ul>
         {
-          geojsonList.map(({ route, properties }) => (
-            <RouteListItem route={route} properties={properties} />
+          geojsonList.map(({ route, properties }, index) => (
+            <RouteListItem
+              route={route}
+              properties={properties}
+              reverse={index % 2 === 1}
+            />
           ))
         }
       </ul>

--- a/src/pages/routes/[route].astro
+++ b/src/pages/routes/[route].astro
@@ -2,16 +2,15 @@
 import type { InferGetStaticParamsType } from "astro";
 import { getCollection, getEntry, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
-import { RouteMap } from "../../components/ui/RouteMap/RouteMap";
 import { FullElevationChart } from "../../components/ui/FullElevationChart/FullElevationChart";
-import { config } from "../../components/markdown";
+import { createEditorialMarkdownComponents } from "../../components/markdown/createEditorialMarkdownComponents";
+import { getPullQuotes } from "../../services/getPullQuotes";
 import { TrailAttributeValue } from "../../components/ui/TrailAttributeValue/TrailAttributeValue";
 import { TrailAttributeName } from "../../components/ui/TrailAttributeName/TrailAttributeName";
 import { mToKm } from "../../services/mToKm";
 import { formatTime } from "../../services/formatTime";
 import { Icon } from "astro-icon/components";
 import TrailAttribute from "../../components/ui/TrailAttribute.astro";
-import RouteMapLegend from "../../components/ui/RouteMapLegend.astro";
 import { Image } from "astro:assets";
 
 export async function getStaticPaths() {
@@ -63,6 +62,13 @@ if (!feature) {
   Astro.response.statusText = "Not found";
   return;
 }
+
+// See src/services/getPullQuotes.ts: pulls the first sentence of every 2nd
+// `##` MDX section as a magazine-style pull-quote breaking the prose
+// column. `entry.data.pullQuotes` is the per-route manual override escape
+// hatch (see content.config.ts).
+const pullQuotes = getPullQuotes(entry.body ?? "", entry.data.pullQuotes);
+const editorialComponents = createEditorialMarkdownComponents(pullQuotes);
 ---
 
 <Layout
@@ -70,33 +76,50 @@ if (!feature) {
   description={entry.data.htmlDescription ?? entry.data.description}
 >
   <div class="max-w-(--breakpoint-xl) mx-auto">
-    <div class="grid grid-cols-1 md:grid-cols-[300px_1fr] gap-8 px-4 xl:px-0">
-      <div>
-        {
-          entry.data.preview?.src && (
-            <div class="relative w-full mb-4" transition:name="map">
-              <Image
-                src={entry.data.preview}
-                width="320"
-                height="320"
-                class=""
-                alt={"Preview of the route on the map"}
-                slot="image"
-              />
-              <a href={`/routes/${route}/map`} class="absolute top-2 right-2">
-                <Icon
-                  name="mdi:arrow-expand"
-                  class="w-8 h-8 text-white bg-green-500 rounded-full p-1 opacity-75 hover:opacity-100 transition-opacity"
-                />
-              </a>
-            </div>
-          )
-        }
-        <div class="relative px-2 lg:px-0">
-          <FullElevationChart client:load points={attitudes} />
+    {
+      entry.data.preview?.src ? (
+        <div
+          class="relative aspect-[21/9] w-full overflow-hidden bg-slate-200"
+          transition:name="map"
+        >
+          <Image
+            src={entry.data.preview}
+            width="1600"
+            height="686"
+            class="h-full w-full object-cover"
+            alt="Preview of the route on the map"
+          />
+          <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent" />
+          <h1 class="font-display absolute bottom-0 left-0 max-w-3xl p-4 text-3xl text-white lg:p-8 lg:text-5xl">
+            {entry.data.title}
+          </h1>
+          <a
+            href={`/routes/${route}/map`}
+            class="absolute top-3 right-3"
+            aria-label="Expand the route map"
+          >
+            <Icon
+              name="mdi:arrow-expand"
+              class="h-8 w-8 rounded-full bg-green-600 p-1.5 text-white opacity-80 transition-opacity hover:opacity-100"
+            />
+          </a>
         </div>
+      ) : (
+        <div class="from-green-700 via-green-600 to-green-700 flex items-end bg-linear-45 px-4 py-16 lg:px-8 lg:py-24">
+          <h1 class="font-display max-w-3xl text-3xl text-white lg:text-5xl">
+            {entry.data.title}
+          </h1>
+        </div>
+      )
+    }
 
-        <div class="py-4 grid grid-cols-2 gap-x-2 gap-y-4 items-center">
+    <div class="grid grid-cols-1 gap-10 px-4 py-8 lg:grid-cols-[1fr_300px] xl:px-0">
+      <div class="max-w-[65ch]">
+        <Content components={editorialComponents} />
+      </div>
+
+      <aside>
+        <div class="grid grid-cols-2 items-center gap-x-2 gap-y-4 pb-6">
           <TrailAttribute>
             <Icon name="mdi:hiking" class="w-5 h-5" slot="icon" />
 
@@ -141,12 +164,11 @@ if (!feature) {
             <TrailAttributeName value="Total Loss" />
           </TrailAttribute>
         </div>
-      </div>
-      <div>
-        <h1 class="py-4 text-4xl">{entry.data.title}</h1>
 
-        <Content components={config} />
-      </div>
+        <div class="relative px-2 lg:px-0">
+          <FullElevationChart client:load points={attitudes} />
+        </div>
+      </aside>
     </div>
   </div>
 </Layout>

--- a/src/services/getPullQuotes.test.ts
+++ b/src/services/getPullQuotes.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { getPullQuotes } from "./getPullQuotes";
+
+const readRouteBody = (path: string): string => {
+  const raw = readFileSync(
+    fileURLToPath(new URL(path, import.meta.url)),
+    "utf8",
+  );
+  return raw.replace(/^---[\s\S]*?---/, "");
+};
+
+describe("getPullQuotes", () => {
+  it("skips the first section and pulls the first sentence from the second section", () => {
+    const body = `
+## Starting point
+
+The route starts at the station. You can get there by train.
+
+## Olivia
+
+One thing that catches the eye is the _Olivia Star_, the highest building in Gdańsk. If you fancy a nice view.
+`;
+
+    const result = getPullQuotes(body);
+
+    expect(result).toEqual([
+      null,
+      {
+        sectionIndex: 1,
+        sectionTitle: "Olivia",
+        quote:
+          "One thing that catches the eye is the Olivia Star, the highest building in Gdańsk.",
+      },
+    ]);
+  });
+
+  it("returns null for a selected section that has no paragraph text", () => {
+    const body = `
+## Starting point
+
+The route starts at the station.
+
+## Elves Valley
+
+## Going back
+
+Back to the start.
+`;
+
+    const result = getPullQuotes(body);
+
+    expect(result).toEqual([null, null, null]);
+  });
+
+  it("applies a manual override to the first selected section instead of the heuristic", () => {
+    const body = `
+## Starting point
+
+The route starts at the station.
+
+## Olivia
+
+One thing that catches the eye is the Olivia Star.
+`;
+
+    const result = getPullQuotes(body, ["A hand-picked pull quote."]);
+
+    expect(result).toEqual([
+      null,
+      {
+        sectionIndex: 1,
+        sectionTitle: "Olivia",
+        quote: "A hand-picked pull quote.",
+      },
+    ]);
+  });
+
+  it("reproduces the worked example from the resolved spec against the real Dolina Elfów content", () => {
+    const body = readRouteBody(
+      "../content/routes/dolina-elfow/dolina-elfow.mdx",
+    );
+
+    const result = getPullQuotes(body);
+
+    expect(result[1]).toEqual({
+      sectionIndex: 1,
+      sectionTitle: "Olivia",
+      quote:
+        "One thing that catches the eye is the Olivia Star, the highest building in Gdańsk.",
+    });
+  });
+});

--- a/src/services/getPullQuotes.ts
+++ b/src/services/getPullQuotes.ts
@@ -1,0 +1,123 @@
+export interface PullQuote {
+  sectionIndex: number;
+  sectionTitle: string;
+  quote: string;
+}
+
+const stripMarkdownEmphasis = (text: string): string =>
+  text
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    .replace(/`([^`]+)`/g, "$1")
+    .trim();
+
+const firstSentence = (paragraph: string): string | null => {
+  const clean = stripMarkdownEmphasis(paragraph.replace(/\s+/g, " ").trim());
+
+  if (!clean) {
+    return null;
+  }
+
+  const match = clean.match(/^.*?[.!?](?=\s|$)/);
+
+  return match ? match[0].trim() : clean;
+};
+
+interface Section {
+  title: string;
+  paragraph: string;
+}
+
+const parseSections = (body: string): Section[] => {
+  const lines = body.split("\n");
+  const sections: Section[] = [];
+
+  let currentTitle: string | null = null;
+  let currentParagraphLines: string[] = [];
+  let capturedFirstParagraph = false;
+
+  const flush = () => {
+    if (currentTitle !== null) {
+      sections.push({
+        title: currentTitle,
+        paragraph: currentParagraphLines.join(" "),
+      });
+    }
+  };
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^##\s+(.*)$/);
+
+    if (headingMatch) {
+      flush();
+      currentTitle = headingMatch[1].trim();
+      currentParagraphLines = [];
+      capturedFirstParagraph = false;
+      continue;
+    }
+
+    if (currentTitle === null) {
+      continue;
+    }
+
+    if (capturedFirstParagraph) {
+      continue;
+    }
+
+    const trimmed = line.trim();
+
+    if (trimmed === "") {
+      if (currentParagraphLines.length > 0) {
+        capturedFirstParagraph = true;
+      }
+      continue;
+    }
+
+    currentParagraphLines.push(trimmed);
+  }
+
+  flush();
+
+  return sections;
+};
+
+/**
+ * Picks a pull-quote for every 2nd `##` section (0-indexed: 1, 3, 5, ...) by
+ * taking the first sentence of that section's opening paragraph. Sections
+ * that aren't selected, or that have no usable opening sentence, map to
+ * `null` so the result stays index-aligned with the MDX section order.
+ *
+ * `overrides` lets a route author replace the heuristic per selected
+ * section (in selection order) via a `pullQuotes` frontmatter field.
+ */
+export function getPullQuotes(
+  body: string,
+  overrides?: string[],
+): (PullQuote | null)[] {
+  const sections = parseSections(body);
+
+  return sections.map((section, index) => {
+    if (index % 2 !== 1) {
+      return null;
+    }
+
+    const overrideIndex = (index - 1) / 2;
+    const override = overrides?.[overrideIndex];
+
+    if (override) {
+      return {
+        sectionIndex: index,
+        sectionTitle: section.title,
+        quote: override,
+      };
+    }
+
+    const quote = firstSentence(section.paragraph);
+
+    if (!quote) {
+      return null;
+    }
+
+    return { sectionIndex: index, sectionTitle: section.title, quote };
+  });
+}

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3,6 +3,15 @@
 @theme {
   --grid-template-columns-header: 50px 1fr 50px;
   --grid-template-columns-layout: 300px 1fr;
+  /* Display serif for the magazine/editorial route layout (prototype
+     issue 07) - headings, pull-quotes, hero titles. Scoped to individual
+     components via `font-display`, not applied to `html`/body text, so it
+     doesn't bleed into other pages' typography. */
+  --font-display: "Fraunces", serif;
+}
+
+@utility font-display {
+  font-family: var(--font-display);
 }
 
 /*


### PR DESCRIPTION
Prototype for [issue 07 — magazine/editorial route layout](../blob/main/.scratch/new-ui-prototypes/issues/07-magazine-editorial-layout.md) (resolved spec, see `## Answer`).

## What this is

A big-type, photography-forward editorial restyle of the route detail page and the two browse pages (`list.astro`/`nearby.astro`) — same pages, same data, only the visual hierarchy changes. This is a **throwaway prototype for design review**, not a finished production PR.

## What changed

- **Route detail (`routes/[route].astro`)**: the existing `preview` image now runs full-width as an `aspect-[21/9]` hero with a scrim and the title overlaid in large serif type, replacing the old 300px sidebar thumbnail. The expand-to-map affordance moves onto the hero. Below it, a two-column grid: prose capped at ~65ch, stat tiles + elevation chart pulled into a non-sticky right-rail "fact box" (spec explicitly calls out not-sticky, to avoid fighting the pull-quotes visually).
- **Automated pull-quotes** (`src/services/getPullQuotes.ts`, TDD'd, 4 unit tests including one that reads the real Dolina Elfów MDX and reproduces the spec's own worked example verbatim): first sentence of every 2nd `##` section's opening paragraph, rendered as a breakout quote right after that heading via a per-page MDX component override (`createEditorialMarkdownComponents.tsx`) — the shared markdown config used by activities/blog content is untouched. A `pullQuotes: string[]` frontmatter field (`content.config.ts`) lets a route author override the heuristic's picks in order, per the spec's own flagged escape hatch.
- **Browse pages**: new `RouteEditorial.astro` variant — alternating photo-left/text-right blocks (~40% photo width, serif title, 2-line description dek, single inline stat line like "5.56km · 1h20 · +196m") — wired into `list.astro`/`nearby.astro` only. The existing `Route.astro`/`ListCardItem` stack (used by `index.astro`'s featured section and the blog embed) is untouched.
- **Typography**: Fraunces added as a display serif (Google Fonts, same preload pattern as the existing Fira Sans), applied via a `font-display` Tailwind utility / `--font-display` token so it only affects components that opt in, not a site-wide font change.
- **Content-gap fallback**: routes without a `preview` fall back to a solid green band with title only. Checked: 2 of the 15 route directories (`droga-marnych-mostow`, `zaspa`) currently lack `preview` — both are `draft: true`, so neither reaches these pages today; the fallback exists defensively.

## A bug found and fixed along the way

Astro renders MDX `<Content>` more than once per page (a headings-metadata pass, then the real render), calling the `h2` override with the identical sequence of heading ids each time. My first cut used a plain call-order counter to track "which section is this" — it double-counted across the two passes and ran off the end of the pull-quote array, so **zero pull-quotes rendered** despite the underlying selection logic being correct. Fixed by keying the section index off the heading's stable `id` (memoized per id) instead of call order. Caught this by literally reverting to the buggy version and watching a new regression test go red before re-applying the fix.

## Review

Ran `/code-review` (standards + spec sub-agents, in parallel). No hard standards violations and no missing/wrong spec requirements came back. Judgement calls noted and left as-is as reasonable for a prototype:
- `createEditorialMarkdownComponents.tsx` is the one stateful component in `src/components/markdown` (a closure-based id→index map) versus its stateless siblings — needed to survive the double-render above; documented inline.
- `getPullQuotes.ts` hand-rolls line-based markdown parsing rather than pulling in `remark`/`mdast` (available transitively via `@astrojs/mdx`, not a declared dependency) — didn't want to add a new direct dependency for a prototype; the manual override field covers cases the heuristic gets wrong.
- The spec's own "explicitly unchanged: ... data shape" line and its own proposed `pullQuotes: string[]` frontmatter mitigation contradict each other; I implemented the frontmatter field since the spec names it explicitly as the risk mitigation.
- `reverse={index % 2 === 1}` is duplicated verbatim across `list.astro` and `nearby.astro` — left inline for a two-line, two-call-site duplicate.

## Flagged risk beyond the spec's own callout

`preview` is not a photograph — it's a 300×300 auto-generated map-line screenshot (`scripts/capture-route-preview.js`). Blown up to a full-width 21:9 hero it looks soft/pixelated on every route (confirmed in the build output). The spec's photography-forward premise assumed real route photography that doesn't exist yet. The layout mechanics — hero shape, two-column grid, pull-quotes, alternating browse blocks — are still valid to evaluate on their own terms; the hero just won't sell the "travel-magazine" mood until either real photos or higher-resolution map captures exist.

## Try it

`pnpm dev`, then visit `/routes/dolina-elfow/`, `/list/`, or `/nearby/`.

## Known caveats

This is prototype code per the `/prototype` skill's rules: no error-handling polish beyond what's needed to run, meant to be judged/iterated on, not merged as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
