### PR TITLE
Prototype: kiosk/big-screen info-board layout (issue #8)

### DIFF
--- a/src/components/ui/KioskCarousel/KioskCarousel.tsx
+++ b/src/components/ui/KioskCarousel/KioskCarousel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import type { KioskRoute } from "./types";
+import { trackEvent } from "../../../services/analytics";
 import {
   goHome,
   openRoute,
@@ -17,8 +18,9 @@ export const KioskCarousel = ({ routes }: { routes: KioskRoute[] }) => {
   const idleTimer = useRef<number | null>(null);
 
   // Any touch input resets the 90s idle clock. When it fires, the kiosk
-  // drops into an unattended attract-mode slideshow (see the effect below)
-  // regardless of where the previous visitor left off.
+  // drops into an unattended attract-mode spotlight cycle on the overview
+  // grid (see the effect below), regardless of where the previous visitor
+  // left off.
   useEffect(() => {
     const scheduleIdleReset = () => {
       if (idleTimer.current !== null) {
@@ -48,10 +50,10 @@ export const KioskCarousel = ({ routes }: { routes: KioskRoute[] }) => {
     };
   }, []);
 
-  // Attract mode auto-advances its own slideshow every 8s. Keyed only on
-  // the mode (not the index) so entering/leaving attract mode starts and
-  // stops a single steady-interval timer, rather than one that restarts
-  // (and skews) on every advance.
+  // Attract mode auto-advances its spotlight every 8s. Keyed only on the
+  // mode (not the index) so entering/leaving attract mode starts and stops
+  // a single steady-interval timer, rather than one that restarts (and
+  // skews) on every advance.
   useEffect(() => {
     if (state.mode !== "attract" || routes.length === 0) {
       return;
@@ -64,29 +66,54 @@ export const KioskCarousel = ({ routes }: { routes: KioskRoute[] }) => {
     return () => window.clearInterval(id);
   }, [state.mode, routes.length]);
 
-  const route = state.mode !== "overview" ? routes[state.index] : undefined;
+  const goHomeAndTrack = () => {
+    trackEvent("kiosk home tapped");
+    setState(goHome());
+  };
+
+  const openRouteAndTrack = (index: number) => {
+    const selected = routes[index];
+
+    if (selected) {
+      trackEvent("kiosk route opened", { slug: selected.slug });
+    }
+
+    setState(openRoute(index));
+  };
+
+  const stepAndTrack = (direction: 1 | -1) => {
+    setState((current) => {
+      const next = stepDetail(current, direction, routes.length);
+      const selected = routes[next.index];
+
+      if (selected) {
+        trackEvent("kiosk route stepped", {
+          slug: selected.slug,
+          direction: direction === 1 ? "next" : "prev",
+        });
+      }
+
+      return next;
+    });
+  };
 
   return (
     <div className="fixed inset-0 bg-slate-950 text-white select-none touch-none overflow-hidden">
-      <HomeButton onClick={() => setState(goHome())} />
+      <HomeButton onClick={goHomeAndTrack} />
 
-      {state.mode === "overview" && (
+      {state.mode !== "detail" && (
         <OverviewGrid
           routes={routes}
-          onSelect={(index) => setState(openRoute(index))}
+          spotlightIndex={state.mode === "attract" ? state.index : null}
+          onSelect={openRouteAndTrack}
         />
       )}
 
-      {route && (
+      {state.mode === "detail" && routes[state.index] && (
         <RouteSlide
-          route={route}
-          isAttract={state.mode === "attract"}
-          onPrev={() =>
-            setState((current) => stepDetail(current, -1, routes.length))
-          }
-          onNext={() =>
-            setState((current) => stepDetail(current, 1, routes.length))
-          }
+          route={routes[state.index]}
+          onPrev={() => stepAndTrack(-1)}
+          onNext={() => stepAndTrack(1)}
         />
       )}
     </div>
@@ -106,9 +133,11 @@ const HomeButton = ({ onClick }: { onClick: () => void }) => (
 
 const OverviewGrid = ({
   routes,
+  spotlightIndex,
   onSelect,
 }: {
   routes: KioskRoute[];
+  spotlightIndex: number | null;
   onSelect: (index: number) => void;
 }) => (
   <div className="h-full w-full overflow-y-auto pt-24 pb-8 px-8">
@@ -125,7 +154,9 @@ const OverviewGrid = ({
           key={route.slug}
           type="button"
           onClick={() => onSelect(index)}
-          className="group relative min-h-[200px] min-w-[200px] overflow-hidden rounded-2xl bg-slate-800 text-left"
+          className={`group relative min-h-[200px] min-w-[200px] overflow-hidden rounded-2xl bg-slate-800 text-left transition-transform ${
+            spotlightIndex === index ? "ring-4 ring-green-400 scale-105" : ""
+          }`}
         >
           {route.previewSrc && (
             <img
@@ -146,12 +177,10 @@ const OverviewGrid = ({
 
 const RouteSlide = ({
   route,
-  isAttract,
   onPrev,
   onNext,
 }: {
   route: KioskRoute;
-  isAttract: boolean;
   onPrev: () => void;
   onNext: () => void;
 }) => (
@@ -180,32 +209,22 @@ const RouteSlide = ({
       </div>
     </div>
 
-    {!isAttract && (
-      <>
-        <button
-          type="button"
-          onClick={onPrev}
-          aria-label="Previous route"
-          className="fixed left-4 top-1/2 z-10 flex h-16 w-16 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 backdrop-blur-sm hover:bg-white/20 active:bg-white/30"
-        >
-          <ChevronIcon direction="left" />
-        </button>
-        <button
-          type="button"
-          onClick={onNext}
-          aria-label="Next route"
-          className="fixed right-4 top-1/2 z-10 flex h-16 w-16 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 backdrop-blur-sm hover:bg-white/20 active:bg-white/30"
-        >
-          <ChevronIcon direction="right" />
-        </button>
-      </>
-    )}
-
-    {isAttract && (
-      <div className="fixed bottom-4 right-4 z-10 rounded-full bg-white/10 px-4 py-2 text-sm uppercase tracking-wide text-slate-200 backdrop-blur-sm">
-        Touch to explore
-      </div>
-    )}
+    <button
+      type="button"
+      onClick={onPrev}
+      aria-label="Previous route"
+      className="fixed left-4 top-1/2 z-10 flex h-16 w-16 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 backdrop-blur-sm hover:bg-white/20 active:bg-white/30"
+    >
+      <ChevronIcon direction="left" />
+    </button>
+    <button
+      type="button"
+      onClick={onNext}
+      aria-label="Next route"
+      className="fixed right-4 top-1/2 z-10 flex h-16 w-16 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 backdrop-blur-sm hover:bg-white/20 active:bg-white/30"
+    >
+      <ChevronIcon direction="right" />
+    </button>
   </div>
 );
 

--- a/src/components/ui/KioskCarousel/KioskCarousel.tsx
+++ b/src/components/ui/KioskCarousel/KioskCarousel.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import type { KioskRoute } from "./types";
+import {
+  goHome,
+  openRoute,
+  stepDetail,
+  handleIdleTimeout,
+  handleInteraction,
+  advanceAttract,
+  type KioskState,
+  IDLE_TIMEOUT_MS,
+  ATTRACT_INTERVAL_MS,
+} from "../../../services/kiosk";
+
+export const KioskCarousel = ({ routes }: { routes: KioskRoute[] }) => {
+  const [state, setState] = useState<KioskState>(goHome());
+  const idleTimer = useRef<number | null>(null);
+
+  // Any touch input resets the 90s idle clock. When it fires, the kiosk
+  // drops into an unattended attract-mode slideshow (see the effect below)
+  // regardless of where the previous visitor left off.
+  useEffect(() => {
+    const scheduleIdleReset = () => {
+      if (idleTimer.current !== null) {
+        window.clearTimeout(idleTimer.current);
+      }
+
+      idleTimer.current = window.setTimeout(() => {
+        setState((current) => handleIdleTimeout(current));
+      }, IDLE_TIMEOUT_MS);
+    };
+
+    scheduleIdleReset();
+
+    const onInteraction = () => {
+      setState((current) => handleInteraction(current));
+      scheduleIdleReset();
+    };
+
+    window.addEventListener("pointerdown", onInteraction);
+
+    return () => {
+      window.removeEventListener("pointerdown", onInteraction);
+
+      if (idleTimer.current !== null) {
+        window.clearTimeout(idleTimer.current);
+      }
+    };
+  }, []);
+
+  // Attract mode auto-advances its own slideshow every 8s. Keyed only on
+  // the mode (not the index) so entering/leaving attract mode starts and
+  // stops a single steady-interval timer, rather than one that restarts
+  // (and skews) on every advance.
+  useEffect(() => {
+    if (state.mode !== "attract" || routes.length === 0) {
+      return;
+    }
+
+    const id = window.setInterval(() => {
+      setState((current) => advanceAttract(current, routes.length));
+    }, ATTRACT_INTERVAL_MS);
+
+    return () => window.clearInterval(id);
+  }, [state.mode, routes.length]);
+
+  const route = state.mode !== "overview" ? routes[state.index] : undefined;
+
+  return (
+    <div className="fixed inset-0 bg-slate-950 text-white select-none touch-none overflow-hidden">
+      <HomeButton onClick={() => setState(goHome())} />
+
+      {state.mode === "overview" && (
+        <OverviewGrid
+          routes={routes}
+          onSelect={(index) => setState(openRoute(index))}
+        />
+      )}
+
+      {route && (
+        <RouteSlide
+          route={route}
+          isAttract={state.mode === "attract"}
+          onPrev={() =>
+            setState((current) => stepDetail(current, -1, routes.length))
+          }
+          onNext={() =>
+            setState((current) => stepDetail(current, 1, routes.length))
+          }
+        />
+      )}
+    </div>
+  );
+};
+
+const HomeButton = ({ onClick }: { onClick: () => void }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label="Home"
+    className="fixed top-4 left-4 z-20 flex h-16 w-16 items-center justify-center rounded-2xl bg-white/10 text-white backdrop-blur-sm hover:bg-white/20 active:bg-white/30"
+  >
+    <HomeIcon />
+  </button>
+);
+
+const OverviewGrid = ({
+  routes,
+  onSelect,
+}: {
+  routes: KioskRoute[];
+  onSelect: (index: number) => void;
+}) => (
+  <div className="h-full w-full overflow-y-auto pt-24 pb-8 px-8">
+    <h1 className="mb-6 text-5xl font-bold">Tricity hiking trails</h1>
+
+    <div
+      className="grid gap-6"
+      style={{
+        gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+      }}
+    >
+      {routes.map((route, index) => (
+        <button
+          key={route.slug}
+          type="button"
+          onClick={() => onSelect(index)}
+          className="group relative min-h-[200px] min-w-[200px] overflow-hidden rounded-2xl bg-slate-800 text-left"
+        >
+          {route.previewSrc && (
+            <img
+              src={route.previewSrc}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover opacity-70 group-hover:opacity-90"
+            />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent" />
+          <span className="absolute bottom-4 left-4 right-4 text-2xl font-semibold">
+            {route.title}
+          </span>
+        </button>
+      ))}
+    </div>
+  </div>
+);
+
+const RouteSlide = ({
+  route,
+  isAttract,
+  onPrev,
+  onNext,
+}: {
+  route: KioskRoute;
+  isAttract: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}) => (
+  <div className="absolute inset-0">
+    {route.previewSrc && (
+      <img
+        src={route.previewSrc}
+        alt=""
+        className="absolute inset-0 h-full w-full object-cover"
+      />
+    )}
+    <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/30 to-black/10" />
+
+    <div className="absolute inset-x-0 bottom-0 p-8 md:p-12">
+      <h2 className="text-5xl font-bold mb-4">{route.title}</h2>
+
+      <p className="max-w-3xl text-xl md:text-2xl text-slate-100 mb-8">
+        {route.summary}
+      </p>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-3xl">
+        <StatTile label="Distance" value={`${route.distanceKm.toFixed(2)}km`} />
+        <StatTile label="Time" value={route.time} />
+        <StatTile label="Total Gain" value={`${route.totalGain.toFixed(0)}m`} />
+        <StatTile label="Total Loss" value={`${route.totalLoss.toFixed(0)}m`} />
+      </div>
+    </div>
+
+    {!isAttract && (
+      <>
+        <button
+          type="button"
+          onClick={onPrev}
+          aria-label="Previous route"
+          className="fixed left-4 top-1/2 z-10 flex h-16 w-16 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 backdrop-blur-sm hover:bg-white/20 active:bg-white/30"
+        >
+          <ChevronIcon direction="left" />
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          aria-label="Next route"
+          className="fixed right-4 top-1/2 z-10 flex h-16 w-16 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 backdrop-blur-sm hover:bg-white/20 active:bg-white/30"
+        >
+          <ChevronIcon direction="right" />
+        </button>
+      </>
+    )}
+
+    {isAttract && (
+      <div className="fixed bottom-4 right-4 z-10 rounded-full bg-white/10 px-4 py-2 text-sm uppercase tracking-wide text-slate-200 backdrop-blur-sm">
+        Touch to explore
+      </div>
+    )}
+  </div>
+);
+
+const StatTile = ({ label, value }: { label: string; value: string }) => (
+  <div>
+    <div className="text-4xl font-semibold">{value}</div>
+    <div className="text-lg uppercase text-slate-300">{label}</div>
+  </div>
+);
+
+const HomeIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="28"
+    height="28"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 11.5 12 4l9 7.5" />
+    <path d="M5 10v9a1 1 0 0 0 1 1h4v-6h4v6h4a1 1 0 0 0 1-1v-9" />
+  </svg>
+);
+
+const ChevronIcon = ({ direction }: { direction: "left" | "right" }) => (
+  <svg
+    viewBox="0 0 24 24"
+    width="28"
+    height="28"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline
+      points={direction === "left" ? "15 18 9 12 15 6" : "9 18 15 12 9 6"}
+    />
+  </svg>
+);

--- a/src/components/ui/KioskCarousel/types.ts
+++ b/src/components/ui/KioskCarousel/types.ts
@@ -1,0 +1,10 @@
+export interface KioskRoute {
+  slug: string;
+  title: string;
+  previewSrc: string | null;
+  distanceKm: number;
+  time: string;
+  totalGain: number;
+  totalLoss: number;
+  summary: string;
+}

--- a/src/layouts/KioskLayout.astro
+++ b/src/layouts/KioskLayout.astro
@@ -1,0 +1,35 @@
+---
+import "../styles/base.css";
+
+// Bare-chrome layout for the public kiosk display: no site header, nav,
+// footer, or cookie-consent banner — none of that makes sense on a
+// touchscreen bolted to a tourist-info desk. The kiosk page supplies its
+// own persistent "Home" affordance instead of the usual site nav.
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title}</title>
+  </head>
+  <body class="overscroll-none">
+    <slot />
+  </body>
+</html>
+
+<style is:global>
+  html {
+    font-family: "Fira Sans", sans-serif;
+    background: #0f172a;
+  }
+</style>

--- a/src/pages/kiosk.astro
+++ b/src/pages/kiosk.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, getEntry } from "astro:content";
+import { getImage } from "astro:assets";
 import KioskLayout from "../layouts/KioskLayout.astro";
 import { enhance } from "../services/enhance";
 import { getLineStringFeature } from "../services/getLineStringFeature";
@@ -28,10 +29,18 @@ for (const route of tricityRoutes) {
   const properties =
     getLineStringFeature({ collection: enhancedGeojson })?.properties ?? {};
 
+  const previewImage = route.data.preview
+    ? await getImage({
+        src: route.data.preview,
+        width: 1600,
+        height: 1600,
+      })
+    : null;
+
   routes.push({
     slug: route.id,
     title: route.data.title,
-    previewSrc: route.data.preview?.src ?? null,
+    previewSrc: previewImage?.src ?? null,
     distanceKm: mToKm(properties.distance ?? 0),
     time: formatTime(properties.estimatedTime ?? 0),
     totalGain: properties.totalGain ?? 0,

--- a/src/pages/kiosk.astro
+++ b/src/pages/kiosk.astro
@@ -1,0 +1,46 @@
+---
+import { getCollection, getEntry } from "astro:content";
+import KioskLayout from "../layouts/KioskLayout.astro";
+import { enhance } from "../services/enhance";
+import { getLineStringFeature } from "../services/getLineStringFeature";
+import { mToKm } from "../services/mToKm";
+import { formatTime } from "../services/formatTime";
+import { firstTwoSentences } from "../services/firstTwoSentences";
+import { KioskCarousel } from "../components/ui/KioskCarousel/KioskCarousel";
+import type { KioskRoute } from "../components/ui/KioskCarousel/types";
+
+// Kiosk mode is scoped to the same in-city route set as routes.astro's
+// homepage map: a tourist-info desk kiosk is pitching the trails around it,
+// not a 2-hour out-of-town trip.
+const allRoutes = await getCollection("routes");
+const tricityRoutes = allRoutes.filter(
+  (route) => !route.data.draft && route.data.tricity,
+);
+
+const routes: KioskRoute[] = [];
+
+for (const route of tricityRoutes) {
+  const geojson = await getEntry(route.data.geojson);
+  const enhancedGeojson = enhance({
+    collection: geojson.data,
+    route: route.data,
+  });
+  const properties =
+    getLineStringFeature({ collection: enhancedGeojson })?.properties ?? {};
+
+  routes.push({
+    slug: route.id,
+    title: route.data.title,
+    previewSrc: route.data.preview?.src ?? null,
+    distanceKm: mToKm(properties.distance ?? 0),
+    time: formatTime(properties.estimatedTime ?? 0),
+    totalGain: properties.totalGain ?? 0,
+    totalLoss: properties.totalLoss ?? 0,
+    summary: firstTwoSentences(route.data.htmlDescription ?? route.data.description),
+  });
+}
+---
+
+<KioskLayout title="Tricity hiking trails — kiosk">
+  <KioskCarousel client:load routes={routes} />
+</KioskLayout>

--- a/src/services/firstTwoSentences.test.ts
+++ b/src/services/firstTwoSentences.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { firstTwoSentences } from "./firstTwoSentences";
+
+describe("firstTwoSentences", () => {
+  it("returns both sentences when there are two or more", () => {
+    expect(
+      firstTwoSentences(
+        "Discover the Dolina Elfów walking route. It starts at Przymorze-Uniwersytet station. It ends near the Olivia Business Centre.",
+      ),
+    ).toBe(
+      "Discover the Dolina Elfów walking route. It starts at Przymorze-Uniwersytet station.",
+    );
+  });
+
+  it("returns the whole text unchanged when it has only one sentence", () => {
+    expect(firstTwoSentences("Bażantarnia Parasol")).toBe(
+      "Bażantarnia Parasol",
+    );
+  });
+
+  it("returns the whole text unchanged when it has exactly one sentence with a period", () => {
+    expect(firstTwoSentences("Park kolibki.")).toBe("Park kolibki.");
+  });
+
+  it("does not split on decimal numbers", () => {
+    expect(firstTwoSentences("The loop is 4.5km long and mostly flat.")).toBe(
+      "The loop is 4.5km long and mostly flat.",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(firstTwoSentences("  A short blurb.  ")).toBe("A short blurb.");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(firstTwoSentences("")).toBe("");
+  });
+});

--- a/src/services/firstTwoSentences.ts
+++ b/src/services/firstTwoSentences.ts
@@ -1,0 +1,20 @@
+// Splits on a period/!/? that is followed by whitespace (or the end of the
+// string), so decimal numbers like "4.5km" don't get treated as a sentence
+// boundary.
+const SENTENCE_BOUNDARY = /(?<=[.!?])\s+(?=\S)/;
+
+/**
+ * Kiosk visitors skim rather than read a full MDX body, so route summaries
+ * are cut down to their first two sentences.
+ */
+export function firstTwoSentences(text: string): string {
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  const sentences = trimmed.split(SENTENCE_BOUNDARY);
+
+  return sentences.slice(0, 2).join(" ");
+}

--- a/src/services/kiosk.test.ts
+++ b/src/services/kiosk.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  goHome,
+  openRoute,
+  stepDetail,
+  handleIdleTimeout,
+  handleInteraction,
+  advanceAttract,
+  IDLE_TIMEOUT_MS,
+  ATTRACT_INTERVAL_MS,
+} from "./kiosk";
+
+describe("kiosk", () => {
+  describe("goHome", () => {
+    it("always resolves to the overview grid", () => {
+      expect(goHome()).toEqual({ mode: "overview", index: 0 });
+    });
+  });
+
+  describe("openRoute", () => {
+    it("opens the given route in detail mode", () => {
+      expect(openRoute(3)).toEqual({ mode: "detail", index: 3 });
+    });
+  });
+
+  describe("stepDetail", () => {
+    it("moves to the next route, wrapping past the end", () => {
+      expect(stepDetail({ mode: "detail", index: 2 }, 1, 3)).toEqual({
+        mode: "detail",
+        index: 0,
+      });
+    });
+
+    it("moves to the previous route, wrapping before the start", () => {
+      expect(stepDetail({ mode: "detail", index: 0 }, -1, 3)).toEqual({
+        mode: "detail",
+        index: 2,
+      });
+    });
+
+    it("exits attract mode into plain detail mode when stepping manually", () => {
+      expect(stepDetail({ mode: "attract", index: 0 }, 1, 3)).toEqual({
+        mode: "detail",
+        index: 1,
+      });
+    });
+
+    it("is a no-op from the overview grid", () => {
+      const state = { mode: "overview" as const, index: 0 };
+      expect(stepDetail(state, 1, 3)).toBe(state);
+    });
+
+    it("is a no-op when there are no routes", () => {
+      const state = { mode: "detail" as const, index: 0 };
+      expect(stepDetail(state, 1, 0)).toBe(state);
+    });
+  });
+
+  describe("handleIdleTimeout", () => {
+    it("drops the overview grid into attract mode starting from the first route", () => {
+      expect(handleIdleTimeout({ mode: "overview", index: 0 })).toEqual({
+        mode: "attract",
+        index: 0,
+      });
+    });
+
+    it("drops an open route detail into attract mode starting from the first route", () => {
+      expect(handleIdleTimeout({ mode: "detail", index: 5 })).toEqual({
+        mode: "attract",
+        index: 0,
+      });
+    });
+
+    it("is a no-op when already in attract mode", () => {
+      const state = { mode: "attract" as const, index: 2 };
+      expect(handleIdleTimeout(state)).toBe(state);
+    });
+  });
+
+  describe("handleInteraction", () => {
+    it("cancels attract mode back to the overview grid", () => {
+      expect(handleInteraction({ mode: "attract", index: 4 })).toEqual({
+        mode: "overview",
+        index: 0,
+      });
+    });
+
+    it("leaves the overview grid unchanged", () => {
+      const state = { mode: "overview" as const, index: 0 };
+      expect(handleInteraction(state)).toBe(state);
+    });
+
+    it("leaves an open route detail unchanged", () => {
+      const state = { mode: "detail" as const, index: 2 };
+      expect(handleInteraction(state)).toBe(state);
+    });
+  });
+
+  describe("advanceAttract", () => {
+    it("advances to the next route, wrapping past the end", () => {
+      expect(advanceAttract({ mode: "attract", index: 2 }, 3)).toEqual({
+        mode: "attract",
+        index: 0,
+      });
+    });
+
+    it("is a no-op outside attract mode", () => {
+      const state = { mode: "detail" as const, index: 0 };
+      expect(advanceAttract(state, 3)).toBe(state);
+    });
+
+    it("is a no-op when there are no routes", () => {
+      const state = { mode: "attract" as const, index: 0 };
+      expect(advanceAttract(state, 0)).toBe(state);
+    });
+  });
+
+  describe("timing constants", () => {
+    it("waits 90s of no touch input before attract mode kicks in", () => {
+      expect(IDLE_TIMEOUT_MS).toBe(90_000);
+    });
+
+    it("advances attract mode every 8s", () => {
+      expect(ATTRACT_INTERVAL_MS).toBe(8_000);
+    });
+  });
+});

--- a/src/services/kiosk.ts
+++ b/src/services/kiosk.ts
@@ -1,0 +1,81 @@
+export type KioskMode = "overview" | "detail" | "attract";
+
+export interface KioskState {
+  mode: KioskMode;
+  index: number;
+}
+
+/** No touch input for this long returns the kiosk to its reset state. */
+export const IDLE_TIMEOUT_MS = 90_000;
+
+/** In attract mode, the current route slide advances at this interval. */
+export const ATTRACT_INTERVAL_MS = 8_000;
+
+/** The persistent "Home" action: always returns to the overview grid. */
+export function goHome(): KioskState {
+  return { mode: "overview", index: 0 };
+}
+
+/** Opens a specific route's full-screen detail slide, e.g. from a grid tap. */
+export function openRoute(index: number): KioskState {
+  return { mode: "detail", index };
+}
+
+/**
+ * Manually pages to the next/previous route detail slide, wrapping around
+ * the ends of the list. A no-op from the overview grid or an empty route
+ * list. Paging manually while in attract mode hands control back to the
+ * visitor by resolving into plain (non-attract) detail mode.
+ */
+export function stepDetail(
+  state: KioskState,
+  direction: 1 | -1,
+  routeCount: number,
+): KioskState {
+  if (state.mode === "overview" || routeCount <= 0) {
+    return state;
+  }
+
+  const nextIndex = (state.index + direction + routeCount) % routeCount;
+
+  return { mode: "detail", index: nextIndex };
+}
+
+/**
+ * After IDLE_TIMEOUT_MS of no touch input, the kiosk resets to attract
+ * mode: a slideshow that starts over from the first route, regardless of
+ * where the visitor left off.
+ */
+export function handleIdleTimeout(state: KioskState): KioskState {
+  if (state.mode === "attract") {
+    return state;
+  }
+
+  return { mode: "attract", index: 0 };
+}
+
+/**
+ * Any touch input cancels attract mode and returns to the overview grid
+ * (not wherever attract mode happened to be showing). Touch input outside
+ * attract mode only resets the idle timer, which the caller handles
+ * separately — the state itself doesn't change.
+ */
+export function handleInteraction(state: KioskState): KioskState {
+  if (state.mode === "attract") {
+    return goHome();
+  }
+
+  return state;
+}
+
+/** Advances attract mode's slideshow by one route, wrapping around. */
+export function advanceAttract(
+  state: KioskState,
+  routeCount: number,
+): KioskState {
+  if (state.mode !== "attract" || routeCount <= 0) {
+    return state;
+  }
+
+  return { mode: "attract", index: (state.index + 1) % routeCount };
+}

--- a/src/services/kiosk.ts
+++ b/src/services/kiosk.ts
@@ -8,8 +8,13 @@ export interface KioskState {
 /** No touch input for this long returns the kiosk to its reset state. */
 export const IDLE_TIMEOUT_MS = 90_000;
 
-/** In attract mode, the current route slide advances at this interval. */
+/** In attract mode, the spotlighted route advances at this interval. */
 export const ATTRACT_INTERVAL_MS = 8_000;
+
+/** Wraps `index + delta` into `[0, count)`, treating the list as a ring. */
+function wrapIndex(index: number, delta: number, count: number): number {
+  return (index + delta + count) % count;
+}
 
 /** The persistent "Home" action: always returns to the overview grid. */
 export function goHome(): KioskState {
@@ -36,15 +41,16 @@ export function stepDetail(
     return state;
   }
 
-  const nextIndex = (state.index + direction + routeCount) % routeCount;
-
-  return { mode: "detail", index: nextIndex };
+  return {
+    mode: "detail",
+    index: wrapIndex(state.index, direction, routeCount),
+  };
 }
 
 /**
  * After IDLE_TIMEOUT_MS of no touch input, the kiosk resets to attract
- * mode: a slideshow that starts over from the first route, regardless of
- * where the visitor left off.
+ * mode: back to the overview grid, spotlighting routes in turn starting
+ * over from the first one, regardless of where the visitor left off.
  */
 export function handleIdleTimeout(state: KioskState): KioskState {
   if (state.mode === "attract") {
@@ -68,7 +74,7 @@ export function handleInteraction(state: KioskState): KioskState {
   return state;
 }
 
-/** Advances attract mode's slideshow by one route, wrapping around. */
+/** Advances attract mode's spotlight to the next route, wrapping around. */
 export function advanceAttract(
   state: KioskState,
   routeCount: number,
@@ -77,5 +83,5 @@ export function advanceAttract(
     return state;
   }
 
-  return { mode: "attract", index: (state.index + 1) % routeCount };
+  return { mode: "attract", index: wrapIndex(state.index, 1, routeCount) };
 }


### PR DESCRIPTION
## What

Implements the resolved spec at `.scratch/new-ui-prototypes/issues/08-kiosk-info-board-layout.md` (issue #8 of the new-ui-prototypes batch): a touch-kiosk presentation of the tricity route set at `/kiosk`, distinct from and additive to the existing shell.

- **`src/layouts/KioskLayout.astro`** — bare chrome: no header, nav, footer, or cookie-consent banner.
- **`src/pages/kiosk.astro`** — loads the same `tricity` + non-draft route set as `routes.astro`'s homepage map, builds each route's stats/summary/preview image, hands off to the island.
- **`src/components/ui/KioskCarousel/KioskCarousel.tsx`** — overview grid (min 200×200px tiles) → full-bleed per-route detail slide (48px title, 36px stat values, 64×64px tap targets for Home/prev/next).
- **`src/services/kiosk.ts`** — pure overview/detail/attract state machine, unit tested: 90s idle timeout drops into an attract-mode spotlight cycle on the overview grid (8s interval, starts over from route 0); any touch cancels attract back to a plain overview; manual paging always resolves into plain detail mode.
- **`src/services/firstTwoSentences.ts`** — trims a route's blurb to two sentences for the kiosk summary.

## Notable decisions / deviations

- **Attract mode renders on the overview grid** (a spotlight ring cycling between tiles every 8s), not a full-screen slideshow — this matches the ticket's literal wording ("auto-return to the overview grid and begin auto-advancing through routes"), a detail I got wrong on the first pass and fixed after code review.
- **Summary text sources `htmlDescription ?? description`**, not the ticket's literal `description` — in this content set, `description` is often a one-word fragment (e.g. `"Elfy"`, `"Sopot"`) while `htmlDescription` holds actual blurb-length prose, matching what `routes/[route].astro` already does for its meta description.
- **Preview images are 300×300 square map crops, not photos.** The ticket assumed a "photo full-bleed" but the actual `preview` asset in this content set is a small map screenshot, so it's visibly soft when upscaled to fill a large kiosk screen. Kept as-is per the ticket's "explicitly unchanged: content collections, data shape" — no new image asset was introduced.
- Checked whether the two tricity routes with literal `"TODO"` description/htmlDescription text (`zaspa`, `droga-marnych-mostow`) could show garbage on-screen — both are `draft: true` and are already excluded by the same `!route.data.draft` filter `routes.astro` uses, so this isn't reachable.
- Per the ticket's own risk flag: this repo has no evidence of an actual kiosk deployment being planned. This stays a low-priority exploratory prototype.

## Testing

- `npx vitest run` — 49/49 passing (18 for the new `kiosk.ts` state machine, 6 for `firstTwoSentences`)
- `npx astro check` — 0 errors
- `npx astro build` — 52 pages build cleanly, including `/kiosk`
- Ran `/code-review` (Standards + Spec axes); addressed all findings: image now goes through `getImage()` like `discover.astro`, key interactions are instrumented via `trackEvent`, a duplicated modulo-wrap was extracted into a shared helper, attract mode's rendering was corrected to show the grid, and the un-spec'd "Touch to explore" pill was removed.