### PR TITLE
Prototype: 5 navigation pattern variants for /routes

### DIFF
--- a/src/components/prototypes/RoutesPrototypeDetailPanel.astro
+++ b/src/components/prototypes/RoutesPrototypeDetailPanel.astro
@@ -1,0 +1,87 @@
+---
+import { Icon } from "astro-icon/components";
+import TrailAttribute from "../ui/TrailAttribute.astro";
+
+interface Props {
+  class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<div
+  data-panel="detail"
+  hidden
+  class:list={["max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0 py-4", className]}
+>
+  <div class="mb-4">
+    <slot name="back" />
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-6">
+    <img
+      data-detail-field="image"
+      hidden
+      class="w-full h-48 md:h-60 object-cover rounded-lg bg-slate-200"
+      alt="Preview of the selected route"
+    />
+
+    <div>
+      <h2
+        data-panel-heading
+        data-detail-field="title"
+        tabindex="-1"
+        class="text-3xl mb-3 outline-none"
+      >
+      </h2>
+
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 max-w-lg mb-4">
+        <TrailAttribute>
+          <Icon name="mdi:hiking" class="w-5 h-5 text-slate-500" slot="icon" />
+          <span
+            data-detail-field="distance"
+            class="text-lg lg:text-xl text-slate-500"></span>
+          <span class="text-xs lg:text-sm text-slate-500">Distance</span>
+        </TrailAttribute>
+
+        <TrailAttribute>
+          <Icon
+            name="mdi:clock-fast"
+            class="w-5 h-5 text-slate-500"
+            slot="icon"
+          />
+          <span
+            data-detail-field="time"
+            class="text-lg lg:text-xl text-slate-500"></span>
+          <span class="text-xs lg:text-sm text-slate-500">Time</span>
+        </TrailAttribute>
+
+        <TrailAttribute>
+          <Icon
+            name="mdi:arrow-top-right-thin"
+            class="w-5 h-5 text-slate-500"
+            slot="icon"
+          />
+          <span
+            data-detail-field="gain"
+            class="text-lg lg:text-xl text-slate-500"></span>
+          <span class="text-xs lg:text-sm text-slate-500">Total Gain</span>
+        </TrailAttribute>
+
+        <TrailAttribute>
+          <Icon
+            name="mdi:arrow-bottom-right-thin"
+            class="w-5 h-5 text-slate-500"
+            slot="icon"
+          />
+          <span
+            data-detail-field="loss"
+            class="text-lg lg:text-xl text-slate-500"></span>
+          <span class="text-xs lg:text-sm text-slate-500">Total Loss</span>
+        </TrailAttribute>
+      </div>
+
+      <p data-detail-field="description" class="text-slate-600 max-w-2xl"></p>
+    </div>
+  </div>
+</div>

--- a/src/components/prototypes/RoutesPrototypeListItem.astro
+++ b/src/components/prototypes/RoutesPrototypeListItem.astro
@@ -1,0 +1,92 @@
+---
+import { Icon } from "astro-icon/components";
+import { Image } from "astro:assets";
+import TrailAttribute from "../ui/TrailAttribute.astro";
+import { TrailAttributeValue } from "../ui/TrailAttributeValue/TrailAttributeValue";
+import { TrailAttributeName } from "../ui/TrailAttributeName/TrailAttributeName";
+import type { RoutesPrototypeListItem } from "../../services/getRoutesPrototypeData";
+
+interface Props {
+  item: RoutesPrototypeListItem;
+}
+
+const { item } = Astro.props;
+---
+
+<li
+  class="my-4 border-b border-solid border-slate-200 last:border-0 w-full group"
+>
+  <a
+    href={`#detail-${item.id}`}
+    data-detail-id={item.id}
+    data-detail-title={item.title}
+    data-detail-description={item.description}
+    data-detail-distance={item.distanceLabel}
+    data-detail-time={item.timeLabel}
+    data-detail-gain={item.gainLabel}
+    data-detail-loss={item.lossLabel}
+    data-detail-image={item.preview?.src}
+    class="grid grid-cols-[80px_1fr] py-4 cursor-pointer"
+  >
+    <div class="row-span-1 sm:row-span-2">
+      {
+        item.preview?.src && (
+          <Image
+            src={item.preview}
+            width="160"
+            height="160"
+            class="w-20 h-20 grayscale-75 group-hover:grayscale-0"
+            alt="Preview of the route on the map"
+          />
+        )
+      }
+    </div>
+
+    <div class="ml-4">
+      <div class="text-2xl flex gap-1 group-hover:text-green-600">
+        <Icon name="mdi:location-on" class="text-green-500" />
+        {item.title}
+      </div>
+    </div>
+
+    <div class="col-span-full sm:col-auto px-4 py-4">
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-lg">
+        <TrailAttribute>
+          <Icon name="mdi:hiking" class="w-5 h-5 text-slate-500" slot="icon" />
+          <TrailAttributeValue value={item.distanceLabel} />
+          <TrailAttributeName value="Distance" />
+        </TrailAttribute>
+
+        <TrailAttribute>
+          <Icon
+            name="mdi:clock-fast"
+            class="w-5 h-5 text-slate-500"
+            slot="icon"
+          />
+          <TrailAttributeValue value={item.timeLabel} />
+          <TrailAttributeName value="Time" />
+        </TrailAttribute>
+
+        <TrailAttribute>
+          <Icon
+            name="mdi:arrow-top-right-thin"
+            class="w-5 h-5 text-slate-500"
+            slot="icon"
+          />
+          <TrailAttributeValue value={item.gainLabel} />
+          <TrailAttributeName value="Total Gain" />
+        </TrailAttribute>
+
+        <TrailAttribute>
+          <Icon
+            name="mdi:arrow-bottom-right-thin"
+            class="w-5 h-5 text-slate-500"
+            slot="icon"
+          />
+          <TrailAttributeValue value={item.lossLabel} />
+          <TrailAttributeName value="Total Loss" />
+        </TrailAttribute>
+      </div>
+    </div>
+  </a>
+</li>

--- a/src/components/prototypes/RoutesPrototypeListPanel.astro
+++ b/src/components/prototypes/RoutesPrototypeListPanel.astro
@@ -1,0 +1,40 @@
+---
+import RoutesPrototypeListItem from "./RoutesPrototypeListItem.astro";
+import type { RoutesPrototypeListItem as ListItem } from "../../services/getRoutesPrototypeData";
+
+interface Props {
+  panelId: "tricity" | "nearby";
+  heading: string;
+  items: ListItem[];
+  class?: string;
+  id?: string;
+  role?: "tabpanel";
+  "aria-labelledby"?: string;
+}
+
+const {
+  panelId,
+  heading,
+  items,
+  class: className = "",
+  id,
+  role,
+  "aria-labelledby": ariaLabelledby,
+} = Astro.props;
+---
+
+<div
+  data-panel={panelId}
+  hidden
+  id={id}
+  role={role}
+  aria-labelledby={ariaLabelledby}
+  class:list={[className]}
+>
+  <h2 data-panel-heading tabindex="-1" class="sr-only">{heading}</h2>
+  <div class="max-w-(--breakpoint-xl) mx-auto relative px-2 lg:px-0">
+    <ul>
+      {items.map((item) => <RoutesPrototypeListItem item={item} />)}
+    </ul>
+  </div>
+</div>

--- a/src/components/prototypes/RoutesPrototypeMapPanel.astro
+++ b/src/components/prototypes/RoutesPrototypeMapPanel.astro
@@ -1,0 +1,47 @@
+---
+import mapImage from "../../assets/home-map.jpg";
+import { HomeMap } from "../ui/HomeMap/HomeMap";
+import RouteMapLegend from "../ui/RouteMapLegend.astro";
+
+interface Props {
+  geojson: GeoJSON.FeatureCollection;
+  class?: string;
+  id?: string;
+  role?: "tabpanel";
+  "aria-labelledby"?: string;
+}
+
+const {
+  geojson,
+  class: className = "",
+  id,
+  role,
+  "aria-labelledby": ariaLabelledby,
+} = Astro.props;
+---
+
+<div
+  data-panel="map"
+  id={id}
+  role={role}
+  aria-labelledby={ariaLabelledby}
+  class:list={[className]}
+>
+  <h2 data-panel-heading tabindex="-1" class="sr-only">Map</h2>
+  <div class="max-w-(--breakpoint-xl) mx-auto relative h-[70vh] px-2 lg:px-0">
+    <div class="absolute inset-0 h-full overflow-hidden">
+      <img src={mapImage.src} class="absolute blur-2xl inset-0 h-full" />
+    </div>
+
+    <HomeMap client:only="preact" routes={geojson} />
+  </div>
+
+  <RouteMapLegend />
+</div>
+
+<style is:global>
+  .maplibregl-map {
+    height: 100%;
+    width: 100%;
+  }
+</style>

--- a/src/config/routesPrototypeNav.ts
+++ b/src/config/routesPrototypeNav.ts
@@ -1,0 +1,149 @@
+export interface PrimarySection {
+  id: string;
+  label: string;
+  href: string;
+  icon: string;
+  description: string;
+}
+
+/**
+ * The site's top-level sections (mirrors Layout.astro's <nav>), reused by
+ * every /routes navigation prototype so the "Routes" entry can point back
+ * at whichever variant is currently open.
+ */
+export const getPrimarySections = (routesHref: string): PrimarySection[] => [
+  {
+    id: "routes",
+    label: "Routes",
+    href: routesHref,
+    icon: "mdi:hiking",
+    description: "Interactive map and trail lists",
+  },
+  {
+    id: "activities",
+    label: "Activities",
+    href: "/activities/",
+    icon: "mdi:bike",
+    description: "Things to do besides hiking",
+  },
+  {
+    id: "food",
+    label: "Food",
+    href: "/food/",
+    icon: "mdi:silverware-fork-knife",
+    description: "Where to eat near the trail",
+  },
+  {
+    id: "transportation",
+    label: "Transportation",
+    href: "/transportation/",
+    icon: "mdi:bus",
+    description: "Getting to the trailheads",
+  },
+  {
+    id: "history",
+    label: "History",
+    href: "/history/",
+    icon: "mdi:bank",
+    description: "Stories behind the region",
+  },
+  {
+    id: "articles",
+    label: "Articles",
+    href: "/blog/the-best-hiking-trails-near-gdansk/",
+    icon: "mdi:newspaper-variant-outline",
+    description: "Guides and write-ups",
+  },
+];
+
+export type RoutesSubsectionId = "map" | "tricity" | "nearby";
+
+export interface RoutesSubsection {
+  id: RoutesSubsectionId;
+  label: string;
+  icon: string;
+  description: string;
+}
+
+/**
+ * The nested subpages that today live at /routes/, /list/ and /nearby/,
+ * modelled here as panels of a single prototype page (plus a "detail" panel
+ * for drilling into a single route) rather than separate routes, so every
+ * pattern can be compared without wiring up 15+ static pages.
+ */
+export const routesSubsections: RoutesSubsection[] = [
+  {
+    id: "map",
+    label: "Map",
+    icon: "mdi:map-outline",
+    description: "Explore trails visually",
+  },
+  {
+    id: "tricity",
+    label: "Tricity",
+    icon: "mdi:format-list-bulleted",
+    description: "Routes within Gdańsk, Sopot & Gdynia",
+  },
+  {
+    id: "nearby",
+    label: "Nearby",
+    icon: "mdi:near-me",
+    description: "A bit further out, still worth it",
+  },
+];
+
+export interface PrototypeVariant {
+  id: string;
+  href: string;
+  name: string;
+  pattern: string;
+  summary: string;
+}
+
+/**
+ * Registry of the 5 prototype variants, used by the small "which prototype
+ * am I looking at" banner each variant renders, and by the index page that
+ * lists them all.
+ */
+export const prototypeVariants: PrototypeVariant[] = [
+  {
+    id: "routes1",
+    href: "/routes1/",
+    name: "Variant 1",
+    pattern: "Sticky tabs + breadcrumb trail",
+    summary:
+      "A refined version of the current tab bar: accessible tablist for Map/Tricity/Nearby, with a breadcrumb trail that grows on drill-down.",
+  },
+  {
+    id: "routes2",
+    href: "/routes2/",
+    name: "Variant 2",
+    pattern: "Mega menu",
+    summary:
+      "The top nav's Routes entry expands into a mega menu that doubles as the section switcher, collapsing into an accordion drawer on mobile.",
+  },
+  {
+    id: "routes3",
+    href: "/routes3/",
+    name: "Variant 3",
+    pattern: "Docked sidebar / nav rail",
+    summary:
+      "A persistent, collapsible sidebar lists every top-level section, auto-expanding Routes into a tree of Map/Tricity/Nearby, docs-site style.",
+  },
+  {
+    id: "routes4",
+    href: "/routes4/",
+    name: "Variant 4",
+    pattern: "Bottom tab bar + segmented control",
+    summary:
+      "Mobile-first app shell: primary sections live in a thumb-reachable bottom bar, with an iOS-style segmented control for the Routes subviews.",
+  },
+  {
+    id: "routes5",
+    href: "/routes5/",
+    name: "Variant 5",
+    pattern: "Breadcrumb-led minimal chrome",
+    summary:
+      "Chrome is stripped to a slim bar and a path (Tricity Hiking / Routes / Map); the last breadcrumb segment opens a sibling switcher.",
+  },
+];

--- a/src/layouts/PrototypeLayout.astro
+++ b/src/layouts/PrototypeLayout.astro
@@ -1,0 +1,83 @@
+---
+import "../styles/base.css";
+import { Icon } from "astro-icon/components";
+import { prototypeVariants } from "../config/routesPrototypeNav";
+
+interface Props {
+  title: string;
+  variantId: string;
+  patternName: string;
+}
+
+const { title, variantId, patternName } = Astro.props;
+
+const currentIndex = prototypeVariants.findIndex(
+  (variant) => variant.id === variantId,
+);
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+    />
+    <title>{title} — Tricity Hiking navigation prototype</title>
+  </head>
+  <body class="bg-slate-50">
+    <div
+      class="flex flex-wrap items-center gap-x-3 gap-y-1 bg-amber-100 border-b border-solid border-amber-300 px-3 py-1.5 text-xs text-amber-900"
+    >
+      <span class="font-semibold">
+        {
+          currentIndex === -1
+            ? patternName
+            : `Prototype ${currentIndex + 1}/5 — ${patternName}`
+        }
+      </span>
+      <span class="opacity-70 hidden sm:inline"
+        >Not linked from the live site.</span
+      >
+      <span class="ml-auto flex items-center gap-2">
+        <a href="/routes-nav-prototypes/" class="underline hover:no-underline">
+          All variants
+        </a>
+        {
+          prototypeVariants.map((variant, index) => (
+            <a
+              href={variant.href}
+              class:list={[
+                "underline hover:no-underline",
+                { "font-semibold no-underline": variant.id === variantId },
+              ]}
+            >
+              {index + 1}
+            </a>
+          ))
+        }
+        <a
+          href="/routes/"
+          class="underline hover:no-underline flex items-center gap-0.5"
+        >
+          Live site <Icon name="mdi:open-in-new" class="w-3 h-3" />
+        </a>
+      </span>
+    </div>
+
+    <slot />
+  </body>
+</html>
+
+<style is:global>
+  html {
+    font-family: "Fira Sans", sans-serif;
+    background: #f8fafc;
+  }
+</style>

--- a/src/pages/routes-nav-prototypes.astro
+++ b/src/pages/routes-nav-prototypes.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * Index of the /routes navigation prototypes (/routes1 .. /routes5).
+ *
+ * Not linked from the live site — this exists purely so the five
+ * variants can be compared side by side while deciding on a direction.
+ */
+import { Icon } from "astro-icon/components";
+import PrototypeLayout from "../layouts/PrototypeLayout.astro";
+import { prototypeVariants } from "../config/routesPrototypeNav";
+---
+
+<PrototypeLayout
+  title="Routes navigation prototypes"
+  variantId=""
+  patternName="Index"
+>
+  <div class="max-w-(--breakpoint-md) mx-auto px-4 py-10">
+    <h1 class="text-3xl mb-2">Routes navigation prototypes</h1>
+    <p class="text-slate-600 mb-8">
+      Five throwaway variants of the navigation around the <code>/routes</code>
+      area, each covering both the site's top-level menu and the nested Map/Tricity/Nearby
+      subviews (plus a route detail drill-down), so the patterns can be compared before
+      picking one to build for real.
+    </p>
+
+    <ul class="flex flex-col gap-4">
+      {
+        prototypeVariants.map((variant, index) => (
+          <li class="border border-solid border-slate-200 rounded-xl p-5 hover:border-green-300 hover:bg-green-50/40">
+            <a href={variant.href} class="flex items-start gap-4">
+              <span class="shrink-0 w-8 h-8 rounded-full bg-green-100 text-green-700 flex items-center justify-center font-semibold">
+                {index + 1}
+              </span>
+              <span class="flex-1">
+                <span class="flex items-center gap-2 text-lg font-medium text-slate-900">
+                  {variant.pattern}
+                  <Icon
+                    name="mdi:arrow-top-right"
+                    class="w-4 h-4 text-slate-400"
+                  />
+                </span>
+                <span class="block text-sm text-slate-600 mt-1">
+                  {variant.summary}
+                </span>
+              </span>
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+</PrototypeLayout>

--- a/src/pages/routes1.astro
+++ b/src/pages/routes1.astro
@@ -1,0 +1,151 @@
+---
+/**
+ * Variant 1 — Sticky tabs + breadcrumb trail.
+ *
+ * A refined version of the site's current pattern:
+ * - top-level nav stays a plain sticky horizontal bar (Jakob's Law: this is
+ *   what visitors already expect from tricity-hiking.pl, so we don't
+ *   reinvent it, only harden it — proper `aria-current`, focus rings).
+ * - the Map/Tricity/Nearby subnav becomes a real ARIA `tablist`
+ *   (role=tab/tabpanel, roving tabindex, arrow-key navigation) instead of
+ *   plain links, so assistive tech announces it as a set of views rather
+ *   than three unrelated links.
+ * - a breadcrumb trail ("Routes / Map") sits under the tabs and grows to a
+ *   third segment when a route is opened, giving explicit "visibility of
+ *   system status" (Nielsen #1) and a one-click way back up the hierarchy
+ *   (Nielsen #3, user control & freedom) that doesn't depend on the
+ *   browser's own back button.
+ */
+import { Icon } from "astro-icon/components";
+import PrototypeLayout from "../layouts/PrototypeLayout.astro";
+import RoutesPrototypeMapPanel from "../components/prototypes/RoutesPrototypeMapPanel.astro";
+import RoutesPrototypeListPanel from "../components/prototypes/RoutesPrototypeListPanel.astro";
+import RoutesPrototypeDetailPanel from "../components/prototypes/RoutesPrototypeDetailPanel.astro";
+import { getRoutesPrototypeData } from "../services/getRoutesPrototypeData";
+import {
+  getPrimarySections,
+  routesSubsections,
+} from "../config/routesPrototypeNav";
+
+const { tricityItems, nearbyItems, mapGeojson } =
+  await getRoutesPrototypeData();
+const primarySections = getPrimarySections("/routes1/");
+---
+
+<PrototypeLayout
+  title="Routes"
+  variantId="routes1"
+  patternName="Sticky tabs + breadcrumb trail"
+>
+  <header
+    class="sticky top-0 z-20 bg-white border-b border-solid border-slate-200"
+  >
+    <nav
+      aria-label="Primary"
+      class="max-w-(--breakpoint-xl) mx-auto flex items-center gap-1 px-2 lg:px-0 py-2 overflow-x-auto"
+    >
+      {
+        primarySections.map((section) => (
+          <a
+            href={section.href}
+            aria-current={section.id === "routes" ? "page" : undefined}
+            class:list={[
+              "px-3 py-2 rounded-lg text-sm whitespace-nowrap",
+              section.id === "routes"
+                ? "text-green-700 font-semibold underline decoration-green-400"
+                : "text-slate-600 hover:bg-slate-100",
+            ]}
+          >
+            {section.label}
+          </a>
+        ))
+      }
+    </nav>
+
+    <div class="max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0">
+      <div role="tablist" aria-label="Routes views" class="flex gap-1 -mb-px">
+        {
+          routesSubsections.map((section, index) => (
+            <button
+              type="button"
+              role="tab"
+              id={`tab-${section.id}`}
+              aria-controls={`panel-${section.id}`}
+              aria-selected={index === 0 ? "true" : "false"}
+              tabindex={index === 0 ? 0 : -1}
+              data-panel-target={section.id}
+              data-state={index === 0 ? "active" : "inactive"}
+              class="flex items-center gap-1.5 px-4 py-2.5 text-sm border-b-2 border-transparent text-slate-600 data-[state=active]:border-green-600 data-[state=active]:text-green-700 data-[state=active]:font-medium hover:text-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-500 rounded-t-md"
+            >
+              <Icon name={section.icon} class="w-4 h-4" />
+              {section.label}
+            </button>
+          ))
+        }
+      </div>
+    </div>
+  </header>
+
+  <div class="max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0 py-3">
+    <nav
+      aria-label="Breadcrumb"
+      class="flex items-center gap-1.5 text-sm text-slate-500"
+    >
+      <Icon name="mdi:home-outline" class="w-4 h-4" />
+      <a href="/" class="hover:underline">Home</a>
+      <Icon name="mdi:chevron-right" class="w-3.5 h-3.5" />
+      <button
+        type="button"
+        data-panel-target="map"
+        class="hover:underline hover:text-green-700"
+      >
+        Routes
+      </button>
+      <Icon name="mdi:chevron-right" class="w-3.5 h-3.5" />
+      <span data-breadcrumb-current class="text-slate-900 font-medium">Map</span
+      >
+    </nav>
+  </div>
+
+  <main class="pb-10">
+    <RoutesPrototypeMapPanel
+      geojson={mapGeojson}
+      id="panel-map"
+      role="tabpanel"
+      aria-labelledby="tab-map"
+    />
+    <RoutesPrototypeListPanel
+      panelId="tricity"
+      heading="Tricity routes"
+      items={tricityItems}
+      id="panel-tricity"
+      role="tabpanel"
+      aria-labelledby="tab-tricity"
+    />
+    <RoutesPrototypeListPanel
+      panelId="nearby"
+      heading="Nearby routes"
+      items={nearbyItems}
+      id="panel-nearby"
+      role="tabpanel"
+      aria-labelledby="tab-nearby"
+    />
+
+    <RoutesPrototypeDetailPanel>
+      <button
+        slot="back"
+        type="button"
+        data-panel-back
+        class="flex items-center gap-1 text-sm text-green-700 hover:underline"
+      >
+        <Icon name="mdi:arrow-left" class="w-4 h-4" />
+        Back to list
+      </button>
+    </RoutesPrototypeDetailPanel>
+  </main>
+</PrototypeLayout>
+
+<script>
+  import { initRoutesPrototypeNav } from "../scripts/routesPrototypeNav.client";
+  initRoutesPrototypeNav();
+</script>

--- a/src/pages/routes2.astro
+++ b/src/pages/routes2.astro
@@ -1,0 +1,210 @@
+---
+/**
+ * Variant 2 — Mega menu.
+ *
+ * The top nav is trimmed to single-word labels; "Routes" becomes a
+ * disclosure button (WAI-ARIA APG "disclosure navigation menu" pattern —
+ * deliberately *not* menu/menuitem roles, which the APG reserves for
+ * action menus, not site navigation) that opens a panel of cards
+ * combining the section's identity with its subviews in one place, so
+ * users pick a subview *while* choosing the section (reduces the number
+ * of decisions per Hick's Law instead of landing on a default view first).
+ *
+ * Once a subview is chosen the menu closes, but a "Viewing: X" chip stays
+ * next to the button as a permanent way back into the switcher — without
+ * it, closing the menu would strand the user with no visible way to
+ * change sections again (Nielsen #3, user control & freedom).
+ *
+ * On narrow screens the same panel reflows from a floating dropdown into
+ * a full-width, in-flow disclosure — the standard responsive mega-menu
+ * collapse, so no separate mobile drawer component is needed.
+ *
+ * The route detail view is framed as an overlay with a close (×) button
+ * rather than a breadcrumb, echoing how the mega menu itself behaves
+ * (open a layer, close the layer) instead of mixing in a different
+ * "drill down" idiom.
+ */
+import { Icon } from "astro-icon/components";
+import PrototypeLayout from "../layouts/PrototypeLayout.astro";
+import RoutesPrototypeMapPanel from "../components/prototypes/RoutesPrototypeMapPanel.astro";
+import RoutesPrototypeListPanel from "../components/prototypes/RoutesPrototypeListPanel.astro";
+import RoutesPrototypeDetailPanel from "../components/prototypes/RoutesPrototypeDetailPanel.astro";
+import { getRoutesPrototypeData } from "../services/getRoutesPrototypeData";
+import {
+  getPrimarySections,
+  routesSubsections,
+} from "../config/routesPrototypeNav";
+
+const { tricityItems, nearbyItems, mapGeojson } =
+  await getRoutesPrototypeData();
+const primarySections = getPrimarySections("/routes2/");
+---
+
+<PrototypeLayout title="Routes" variantId="routes2" patternName="Mega menu">
+  <header class="relative z-20 bg-slate-900 text-white">
+    <div
+      class="max-w-(--breakpoint-xl) mx-auto flex items-center gap-1 px-2 lg:px-0 py-2"
+    >
+      {
+        primarySections.map((section) =>
+          section.id === "routes" ? (
+            <button
+              type="button"
+              data-mega-menu-trigger
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-controls="mega-menu-panel"
+              class="px-3 py-2 rounded-lg text-sm font-semibold bg-white/10 flex items-center gap-1"
+            >
+              {section.label}
+              <Icon name="mdi:chevron-down" class="w-4 h-4" />
+            </button>
+          ) : (
+            <a
+              href={section.href}
+              class="px-3 py-2 rounded-lg text-sm text-slate-300 hover:bg-white/10 hover:text-white whitespace-nowrap"
+            >
+              {section.label}
+            </a>
+          ),
+        )
+      }
+    </div>
+
+    <div
+      id="mega-menu-panel"
+      data-mega-menu-panel
+      hidden
+      class="border-t border-white/10 bg-slate-900 md:absolute md:inset-x-0 md:shadow-xl md:border-b"
+    >
+      <nav
+        aria-label="Routes sections"
+        class="max-w-(--breakpoint-xl) mx-auto grid grid-cols-1 sm:grid-cols-3 gap-3 px-2 lg:px-0 py-4"
+      >
+        {
+          routesSubsections.map((section) => (
+            <button
+              type="button"
+              data-panel-target={section.id}
+              class="text-left p-4 rounded-xl bg-white/5 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-400"
+            >
+              <span class="flex items-center gap-2 text-base font-medium mb-1">
+                <Icon name={section.icon} class="w-5 h-5 text-green-400" />
+                {section.label}
+              </span>
+              <span class="text-sm text-slate-400">{section.description}</span>
+            </button>
+          ))
+        }
+      </nav>
+    </div>
+  </header>
+
+  <div
+    class="max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0 py-4 flex items-center justify-between flex-wrap gap-2"
+  >
+    <h1 class="text-2xl">Best hiking trails near Gdańsk, Sopot, and Gdynia</h1>
+
+    <button
+      type="button"
+      data-mega-menu-chip
+      class="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-green-50 border border-solid border-green-300 text-sm text-slate-700 hover:bg-green-100"
+    >
+      Viewing:
+      <span data-breadcrumb-current class="font-semibold text-green-700"
+        >Map</span
+      >
+      <Icon name="mdi:chevron-down" class="w-3.5 h-3.5" />
+    </button>
+  </div>
+
+  <main class="pb-10">
+    <RoutesPrototypeMapPanel geojson={mapGeojson} />
+    <RoutesPrototypeListPanel
+      panelId="tricity"
+      heading="Tricity routes"
+      items={tricityItems}
+    />
+    <RoutesPrototypeListPanel
+      panelId="nearby"
+      heading="Nearby routes"
+      items={nearbyItems}
+    />
+
+    <RoutesPrototypeDetailPanel>
+      <button
+        slot="back"
+        type="button"
+        data-panel-back
+        aria-label="Close route details"
+        class="ml-auto flex items-center gap-1 px-3 py-1.5 rounded-full bg-slate-100 hover:bg-slate-200 text-sm text-slate-700"
+      >
+        <Icon name="mdi:close" class="w-4 h-4" />
+        Close
+      </button>
+    </RoutesPrototypeDetailPanel>
+  </main>
+</PrototypeLayout>
+
+<script>
+  import { initRoutesPrototypeNav } from "../scripts/routesPrototypeNav.client";
+  initRoutesPrototypeNav();
+
+  const menuButton = document.querySelector<HTMLButtonElement>(
+    "[data-mega-menu-trigger]",
+  );
+  const menuPanel = document.querySelector<HTMLElement>(
+    "[data-mega-menu-panel]",
+  );
+  const chipButton = document.querySelector<HTMLButtonElement>(
+    "[data-mega-menu-chip]",
+  );
+
+  const openMenu = () => {
+    if (!menuPanel || !menuButton) return;
+    menuPanel.hidden = false;
+    menuButton.setAttribute("aria-expanded", "true");
+  };
+
+  const closeMenu = () => {
+    if (!menuPanel || !menuButton) return;
+    menuPanel.hidden = true;
+    menuButton.setAttribute("aria-expanded", "false");
+  };
+
+  const toggleMenu = () => {
+    if (!menuPanel) return;
+    if (menuPanel.hidden) openMenu();
+    else closeMenu();
+  };
+
+  menuButton?.addEventListener("click", toggleMenu);
+  chipButton?.addEventListener("click", toggleMenu);
+
+  menuPanel?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement;
+    if (target.closest("[data-panel-target]")) {
+      closeMenu();
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!menuPanel || menuPanel.hidden) return;
+    const target = event.target as HTMLElement;
+    if (
+      menuPanel.contains(target) ||
+      menuButton?.contains(target) ||
+      chipButton?.contains(target)
+    ) {
+      return;
+    }
+    closeMenu();
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && menuPanel && !menuPanel.hidden) {
+      closeMenu();
+      menuButton?.focus();
+    }
+  });
+</script>

--- a/src/pages/routes3.astro
+++ b/src/pages/routes3.astro
@@ -1,0 +1,248 @@
+---
+/**
+ * Variant 3 — Docked sidebar / nav rail.
+ *
+ * Top-level sections and the Routes subviews live in one persistent
+ * structure instead of two separate bars — a pattern users already know
+ * from docs sites and SaaS dashboards (Jakob's Law), which scales better
+ * than a horizontal bar once a section has its own sub-navigation: the
+ * active section (Routes) auto-expands into a tree of Map/Tricity/Nearby,
+ * so the whole hierarchy — where am I, what else is in this section, what
+ * are the other sections — is visible at a glance without extra clicks.
+ *
+ * The rail collapses to icons-only on desktop (a `data-sidebar-label`
+ * contract lets one toggle hide every label at once) to reclaim width for
+ * the map, and becomes an off-canvas drawer with a backdrop on mobile —
+ * both standard treatments for this pattern (Gmail's nav rail; any
+ * mobile app's slide-in drawer).
+ */
+import { Icon } from "astro-icon/components";
+import PrototypeLayout from "../layouts/PrototypeLayout.astro";
+import RoutesPrototypeMapPanel from "../components/prototypes/RoutesPrototypeMapPanel.astro";
+import RoutesPrototypeListPanel from "../components/prototypes/RoutesPrototypeListPanel.astro";
+import RoutesPrototypeDetailPanel from "../components/prototypes/RoutesPrototypeDetailPanel.astro";
+import { getRoutesPrototypeData } from "../services/getRoutesPrototypeData";
+import {
+  getPrimarySections,
+  routesSubsections,
+} from "../config/routesPrototypeNav";
+
+const { tricityItems, nearbyItems, mapGeojson } =
+  await getRoutesPrototypeData();
+const primarySections = getPrimarySections("/routes3/");
+---
+
+<PrototypeLayout
+  title="Routes"
+  variantId="routes3"
+  patternName="Docked sidebar / nav rail"
+>
+  <div class="lg:flex lg:min-h-[calc(100vh-32px)]">
+    <div
+      data-sidebar-backdrop
+      hidden
+      class="fixed inset-0 bg-black/40 z-30 lg:hidden"
+    >
+    </div>
+
+    <aside
+      data-sidebar
+      class="fixed lg:static inset-y-0 left-0 z-40 w-72 lg:w-64 bg-slate-900 text-white flex flex-col shrink-0 -translate-x-full lg:translate-x-0 transition-[transform,width] duration-200"
+    >
+      <div
+        class="flex items-center justify-between px-3 py-3 border-b border-white/10"
+      >
+        <a href="/" class="text-sm font-semibold" data-sidebar-label>
+          Tricity Hiking
+        </a>
+        <button
+          type="button"
+          data-sidebar-collapse-toggle
+          aria-expanded="true"
+          aria-label="Collapse sidebar"
+          class="hidden lg:flex p-1.5 rounded hover:bg-white/10"
+        >
+          <Icon
+            data-sidebar-collapse-icon
+            name="mdi:arrow-collapse-left"
+            class="w-4 h-4"
+          />
+        </button>
+        <button
+          type="button"
+          data-sidebar-close
+          aria-label="Close menu"
+          class="lg:hidden p-1.5 rounded hover:bg-white/10"
+        >
+          <Icon name="mdi:close" class="w-5 h-5" />
+        </button>
+      </div>
+
+      <nav aria-label="Primary" class="flex-1 overflow-y-auto py-2">
+        <ul class="flex flex-col gap-0.5 px-2">
+          {
+            primarySections.map((section) => (
+              <li>
+                {section.id === "routes" ? (
+                  <div>
+                    <button
+                      type="button"
+                      data-panel-target="map"
+                      class="w-full flex items-center gap-3 px-3 py-2 rounded-lg bg-white/10 text-green-400 text-sm font-medium"
+                    >
+                      <Icon name={section.icon} class="w-5 h-5 shrink-0" />
+                      <span data-sidebar-label>{section.label}</span>
+                    </button>
+                    <ul
+                      data-sidebar-label
+                      class="mt-1 ml-4 pl-4 border-l border-white/10 flex flex-col gap-0.5"
+                    >
+                      {routesSubsections.map((sub, index) => (
+                        <li>
+                          <button
+                            type="button"
+                            data-panel-target={sub.id}
+                            data-state={index === 0 ? "active" : "inactive"}
+                            class="w-full flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-slate-300 hover:bg-white/10 hover:text-white data-[state=active]:bg-white/10 data-[state=active]:text-white data-[state=active]:font-medium"
+                          >
+                            <Icon name={sub.icon} class="w-4 h-4 shrink-0" />
+                            {sub.label}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : (
+                  <a
+                    href={section.href}
+                    class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-slate-300 hover:bg-white/10 hover:text-white"
+                  >
+                    <Icon name={section.icon} class="w-5 h-5 shrink-0" />
+                    <span data-sidebar-label>{section.label}</span>
+                  </a>
+                )}
+              </li>
+            ))
+          }
+        </ul>
+      </nav>
+    </aside>
+
+    <div class="flex-1 min-w-0">
+      <header
+        class="lg:hidden sticky top-0 z-20 bg-white border-b border-solid border-slate-200 flex items-center gap-2 px-2 py-2"
+      >
+        <button
+          type="button"
+          data-sidebar-open
+          aria-label="Open menu"
+          class="p-2 rounded hover:bg-slate-100"
+        >
+          <Icon name="mdi:menu" class="w-6 h-6" />
+        </button>
+        <span class="text-sm font-medium">Routes</span>
+      </header>
+
+      <div class="px-2 lg:px-4 py-3">
+        <nav
+          aria-label="Breadcrumb"
+          class="flex items-center gap-1.5 text-sm text-slate-500"
+        >
+          <span>Routes</span>
+          <Icon name="mdi:chevron-right" class="w-3.5 h-3.5" />
+          <span data-breadcrumb-current class="text-slate-900 font-medium"
+            >Map</span
+          >
+        </nav>
+      </div>
+
+      <main class="pb-10">
+        <RoutesPrototypeMapPanel geojson={mapGeojson} />
+        <RoutesPrototypeListPanel
+          panelId="tricity"
+          heading="Tricity routes"
+          items={tricityItems}
+        />
+        <RoutesPrototypeListPanel
+          panelId="nearby"
+          heading="Nearby routes"
+          items={nearbyItems}
+        />
+
+        <RoutesPrototypeDetailPanel>
+          <button
+            slot="back"
+            type="button"
+            data-panel-back
+            class="flex items-center gap-1 text-sm text-green-700 hover:underline"
+          >
+            <Icon name="mdi:arrow-left" class="w-4 h-4" />
+            Back to list
+          </button>
+        </RoutesPrototypeDetailPanel>
+      </main>
+    </div>
+  </div>
+</PrototypeLayout>
+
+<script>
+  import { initRoutesPrototypeNav } from "../scripts/routesPrototypeNav.client";
+  initRoutesPrototypeNav();
+
+  const sidebar = document.querySelector<HTMLElement>("[data-sidebar]");
+  const backdrop = document.querySelector<HTMLElement>(
+    "[data-sidebar-backdrop]",
+  );
+  const openButton = document.querySelector<HTMLButtonElement>(
+    "[data-sidebar-open]",
+  );
+  const closeButton = document.querySelector<HTMLButtonElement>(
+    "[data-sidebar-close]",
+  );
+  const collapseToggle = document.querySelector<HTMLButtonElement>(
+    "[data-sidebar-collapse-toggle]",
+  );
+  const collapseIcon = document.querySelector<HTMLElement>(
+    "[data-sidebar-collapse-icon]",
+  );
+  const labels = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-sidebar-label]"),
+  );
+
+  const openDrawer = () => {
+    sidebar?.classList.remove("-translate-x-full");
+    sidebar?.classList.add("translate-x-0");
+    if (backdrop) backdrop.hidden = false;
+  };
+
+  const closeDrawer = () => {
+    sidebar?.classList.add("-translate-x-full");
+    sidebar?.classList.remove("translate-x-0");
+    if (backdrop) backdrop.hidden = true;
+  };
+
+  openButton?.addEventListener("click", openDrawer);
+  closeButton?.addEventListener("click", closeDrawer);
+  backdrop?.addEventListener("click", closeDrawer);
+
+  sidebar?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement;
+    if (window.innerWidth < 1024 && target.closest("[data-panel-target]")) {
+      closeDrawer();
+    }
+  });
+
+  collapseToggle?.addEventListener("click", () => {
+    const collapsed = !sidebar?.classList.contains("lg:w-16");
+    sidebar?.classList.toggle("lg:w-16", collapsed);
+    sidebar?.classList.toggle("lg:w-64", !collapsed);
+    labels.forEach((label) => label.classList.toggle("lg:hidden", collapsed));
+    collapseToggle.setAttribute("aria-expanded", String(!collapsed));
+    collapseToggle.setAttribute(
+      "aria-label",
+      collapsed ? "Expand sidebar" : "Collapse sidebar",
+    );
+    collapseIcon?.classList.toggle("rotate-180", collapsed);
+    window.dispatchEvent(new Event("resize"));
+  });
+</script>

--- a/src/pages/routes4.astro
+++ b/src/pages/routes4.astro
@@ -87,6 +87,8 @@ const overflowSections = primarySections.slice(3);
           <button
             type="button"
             role="tab"
+            id={`tab-${section.id}`}
+            aria-controls={`panel-${section.id}`}
             aria-selected={index === 0 ? "true" : "false"}
             tabindex={index === 0 ? 0 : -1}
             data-panel-target={section.id}
@@ -107,16 +109,27 @@ const overflowSections = primarySections.slice(3);
   </div>
 
   <main class="pb-24 lg:pb-10">
-    <RoutesPrototypeMapPanel geojson={mapGeojson} />
+    <RoutesPrototypeMapPanel
+      geojson={mapGeojson}
+      id="panel-map"
+      role="tabpanel"
+      aria-labelledby="tab-map"
+    />
     <RoutesPrototypeListPanel
       panelId="tricity"
       heading="Tricity routes"
       items={tricityItems}
+      id="panel-tricity"
+      role="tabpanel"
+      aria-labelledby="tab-tricity"
     />
     <RoutesPrototypeListPanel
       panelId="nearby"
       heading="Nearby routes"
       items={nearbyItems}
+      id="panel-nearby"
+      role="tabpanel"
+      aria-labelledby="tab-nearby"
     />
 
     <RoutesPrototypeDetailPanel

--- a/src/pages/routes4.astro
+++ b/src/pages/routes4.astro
@@ -1,0 +1,250 @@
+---
+/**
+ * Variant 4 — Bottom tab bar + segmented control.
+ *
+ * Mobile-first app shell: the primary sections sit in a fixed bottom tab
+ * bar on small screens, in the thumb's easy reach (Fitts's Law) rather
+ * than requiring a stretch to the top of a tall phone screen. Bottom bars
+ * are conventionally capped at ~5 destinations (Material Design, Apple
+ * HIG) — with 6 sections, the least central three (Transportation,
+ * History, Articles) are grouped behind a "More" sheet instead of being
+ * crammed in or silently dropped. On desktop, where reach isn't a
+ * constraint and there's room for every label, the same items promote to
+ * an ordinary top bar.
+ *
+ * Inside Routes, an iOS-style segmented control — a second, visually
+ * distinct level of control — switches Map/Tricity/Nearby, keeping the
+ * "which section" and "which view within the section" decisions clearly
+ * separated instead of flattening them into one bar.
+ *
+ * A route's detail opens as a bottom sheet (drag handle + "Done"),
+ * matching how Google/Apple Maps present a picked result over a list —
+ * on wider screens the same panel simply renders as a centered card.
+ */
+import { Icon } from "astro-icon/components";
+import PrototypeLayout from "../layouts/PrototypeLayout.astro";
+import RoutesPrototypeMapPanel from "../components/prototypes/RoutesPrototypeMapPanel.astro";
+import RoutesPrototypeListPanel from "../components/prototypes/RoutesPrototypeListPanel.astro";
+import RoutesPrototypeDetailPanel from "../components/prototypes/RoutesPrototypeDetailPanel.astro";
+import { getRoutesPrototypeData } from "../services/getRoutesPrototypeData";
+import {
+  getPrimarySections,
+  routesSubsections,
+} from "../config/routesPrototypeNav";
+
+const { tricityItems, nearbyItems, mapGeojson } =
+  await getRoutesPrototypeData();
+const primarySections = getPrimarySections("/routes4/");
+const bottomBarSections = primarySections.slice(0, 3);
+const overflowSections = primarySections.slice(3);
+---
+
+<PrototypeLayout
+  title="Routes"
+  variantId="routes4"
+  patternName="Bottom tab bar + segmented control"
+>
+  <!-- Desktop top bar: same destinations, no need to group under "More". -->
+  <header
+    class="hidden lg:block sticky top-0 z-20 bg-white border-b border-solid border-slate-200"
+  >
+    <nav
+      aria-label="Primary"
+      class="max-w-(--breakpoint-xl) mx-auto flex items-center gap-1 px-2 lg:px-0 py-2"
+    >
+      {
+        primarySections.map((section) => (
+          <a
+            href={section.href}
+            aria-current={section.id === "routes" ? "page" : undefined}
+            class:list={[
+              "flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm",
+              section.id === "routes"
+                ? "text-green-700 font-semibold bg-green-50"
+                : "text-slate-600 hover:bg-slate-100",
+            ]}
+          >
+            <Icon name={section.icon} class="w-4 h-4" />
+            {section.label}
+          </a>
+        ))
+      }
+    </nav>
+  </header>
+
+  <div class="max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0 py-4">
+    <h1 class="text-2xl mb-3">
+      Best hiking trails near Gdańsk, Sopot, and Gdynia
+    </h1>
+
+    <div
+      role="tablist"
+      aria-label="Routes views"
+      class="inline-flex p-1 bg-slate-100 rounded-full"
+    >
+      {
+        routesSubsections.map((section, index) => (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={index === 0 ? "true" : "false"}
+            tabindex={index === 0 ? 0 : -1}
+            data-panel-target={section.id}
+            data-state={index === 0 ? "active" : "inactive"}
+            class="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm text-slate-600 data-[state=active]:bg-white data-[state=active]:text-green-700 data-[state=active]:shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-500"
+          >
+            <Icon name={section.icon} class="w-4 h-4" />
+            {section.label}
+          </button>
+        ))
+      }
+    </div>
+    <p class="text-xs text-slate-400 mt-1.5">
+      Showing: <span data-breadcrumb-current class="font-medium text-slate-600"
+        >Map</span
+      >
+    </p>
+  </div>
+
+  <main class="pb-24 lg:pb-10">
+    <RoutesPrototypeMapPanel geojson={mapGeojson} />
+    <RoutesPrototypeListPanel
+      panelId="tricity"
+      heading="Tricity routes"
+      items={tricityItems}
+    />
+    <RoutesPrototypeListPanel
+      panelId="nearby"
+      heading="Nearby routes"
+      items={nearbyItems}
+    />
+
+    <RoutesPrototypeDetailPanel
+      class="fixed inset-x-0 bottom-0 z-40 bg-white rounded-t-2xl shadow-2xl max-h-[85vh] overflow-y-auto md:static md:rounded-2xl md:shadow md:max-w-2xl md:mx-auto md:my-8 md:max-h-none md:overflow-visible"
+    >
+      <div slot="back" class="flex flex-col gap-2">
+        <div
+          aria-hidden="true"
+          class="mx-auto w-10 h-1.5 rounded-full bg-slate-300 md:hidden"
+        >
+        </div>
+        <div class="flex justify-end">
+          <button
+            type="button"
+            data-panel-back
+            class="text-sm font-medium text-green-700 hover:underline"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </RoutesPrototypeDetailPanel>
+  </main>
+
+  <!-- Mobile bottom tab bar. -->
+  <nav
+    aria-label="Primary"
+    class="lg:hidden fixed bottom-0 inset-x-0 z-30 bg-white border-t border-solid border-slate-200 flex"
+    style="padding-bottom: env(safe-area-inset-bottom);"
+  >
+    {
+      bottomBarSections.map((section) => (
+        <a
+          href={section.href}
+          aria-current={section.id === "routes" ? "page" : undefined}
+          class:list={[
+            "flex-1 flex flex-col items-center gap-0.5 py-2 text-xs",
+            section.id === "routes" ? "text-green-700" : "text-slate-500",
+          ]}
+        >
+          <Icon name={section.icon} class="w-5 h-5" />
+          {section.label}
+        </a>
+      ))
+    }
+    <button
+      type="button"
+      data-more-trigger
+      aria-haspopup="true"
+      aria-expanded="false"
+      aria-controls="more-sheet"
+      class="flex-1 flex flex-col items-center gap-0.5 py-2 text-xs text-slate-500"
+    >
+      <Icon name="mdi:dots-horizontal" class="w-5 h-5" />
+      More
+    </button>
+  </nav>
+
+  <div
+    data-more-backdrop
+    hidden
+    class="lg:hidden fixed inset-0 z-30 bg-black/40"
+  >
+  </div>
+  <div
+    id="more-sheet"
+    data-more-sheet
+    hidden
+    class="lg:hidden fixed inset-x-0 bottom-0 z-40 bg-white rounded-t-2xl shadow-2xl pb-[calc(1rem+env(safe-area-inset-bottom))]"
+  >
+    <div
+      class="mx-auto w-10 h-1.5 rounded-full bg-slate-300 mt-3 mb-2"
+      aria-hidden="true"
+    >
+    </div>
+    <ul class="px-4 py-2">
+      {
+        overflowSections.map((section) => (
+          <li>
+            <a
+              href={section.href}
+              class="flex items-center gap-3 py-3 text-slate-700"
+            >
+              <Icon name={section.icon} class="w-5 h-5 text-slate-500" />
+              {section.label}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+</PrototypeLayout>
+
+<script>
+  import { initRoutesPrototypeNav } from "../scripts/routesPrototypeNav.client";
+  initRoutesPrototypeNav();
+
+  const moreTrigger = document.querySelector<HTMLButtonElement>(
+    "[data-more-trigger]",
+  );
+  const moreSheet = document.querySelector<HTMLElement>("[data-more-sheet]");
+  const moreBackdrop = document.querySelector<HTMLElement>(
+    "[data-more-backdrop]",
+  );
+
+  const openSheet = () => {
+    if (!moreSheet || !moreTrigger) return;
+    moreSheet.hidden = false;
+    if (moreBackdrop) moreBackdrop.hidden = false;
+    moreTrigger.setAttribute("aria-expanded", "true");
+  };
+
+  const closeSheet = () => {
+    if (!moreSheet || !moreTrigger) return;
+    moreSheet.hidden = true;
+    if (moreBackdrop) moreBackdrop.hidden = true;
+    moreTrigger.setAttribute("aria-expanded", "false");
+  };
+
+  moreTrigger?.addEventListener("click", () => {
+    if (moreSheet?.hidden) openSheet();
+    else closeSheet();
+  });
+  moreBackdrop?.addEventListener("click", closeSheet);
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && moreSheet && !moreSheet.hidden) {
+      closeSheet();
+      moreTrigger?.focus();
+    }
+  });
+</script>

--- a/src/pages/routes5.astro
+++ b/src/pages/routes5.astro
@@ -1,0 +1,309 @@
+---
+/**
+ * Variant 5 — Breadcrumb-led minimal chrome.
+ *
+ * Chrome is stripped to a slim bar (logo, search, hamburger) so the map —
+ * the reason people come to this page — gets the vertical space instead
+ * of a tab row. Wayfinding moves into a path directly under the header:
+ * "Tricity Hiking / Routes / Map", each segment a real link up the
+ * hierarchy (classic breadcrumb, Nielsen #1 visibility of system status).
+ *
+ * The last segment doubles as a switcher: its caret opens a small menu of
+ * sibling views, so choosing "Tricity" or "Nearby" happens *in place* of
+ * the current segment rather than needing a whole separate control row —
+ * a pattern borrowed from Notion/Google Drive's path bar. Opening a route
+ * grows the path by one segment and offers "back to list" from the same
+ * menu, so one mechanism serves both switching sibling subviews and
+ * climbing back out of a route.
+ *
+ * All top-level sections still exist, just moved off the persistent bar
+ * and into a full-screen menu behind the hamburger — appropriate here
+ * because, unlike the other variants, this page is optimized for one
+ * section (Routes) rather than for hopping between all of them.
+ */
+import { Icon } from "astro-icon/components";
+import PrototypeLayout from "../layouts/PrototypeLayout.astro";
+import RoutesPrototypeMapPanel from "../components/prototypes/RoutesPrototypeMapPanel.astro";
+import RoutesPrototypeListPanel from "../components/prototypes/RoutesPrototypeListPanel.astro";
+import RoutesPrototypeDetailPanel from "../components/prototypes/RoutesPrototypeDetailPanel.astro";
+import { getRoutesPrototypeData } from "../services/getRoutesPrototypeData";
+import {
+  getPrimarySections,
+  routesSubsections,
+} from "../config/routesPrototypeNav";
+
+const { tricityItems, nearbyItems, mapGeojson } =
+  await getRoutesPrototypeData();
+const primarySections = getPrimarySections("/routes5/");
+---
+
+<PrototypeLayout
+  title="Routes"
+  variantId="routes5"
+  patternName="Breadcrumb-led minimal chrome"
+>
+  <header
+    class="sticky top-0 z-20 bg-white border-b border-solid border-slate-200"
+  >
+    <div
+      class="max-w-(--breakpoint-xl) mx-auto flex items-center justify-between px-2 lg:px-0 py-2"
+    >
+      <a href="/" class="flex items-center gap-2">
+        <Icon name="mdi:hiking" class="w-5 h-5 text-green-600" />
+        <span class="text-sm font-semibold">Tricity Hiking</span>
+      </a>
+      <div class="flex items-center gap-1">
+        <button
+          type="button"
+          aria-label="Search (not wired up in this prototype)"
+          class="p-2 rounded hover:bg-slate-100"
+        >
+          <Icon name="mdi:magnify" class="w-5 h-5 text-slate-500" />
+        </button>
+        <button
+          type="button"
+          data-menu-trigger
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="site-menu"
+          aria-label="Open menu"
+          class="p-2 rounded hover:bg-slate-100"
+        >
+          <Icon name="mdi:menu" class="w-5 h-5 text-slate-700" />
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div
+    id="site-menu"
+    data-menu-panel
+    hidden
+    class="fixed inset-0 z-40 bg-white overflow-y-auto"
+  >
+    <div
+      class="max-w-(--breakpoint-xl) mx-auto flex items-center justify-between px-2 lg:px-0 py-3"
+    >
+      <span class="text-sm font-semibold">Menu</span>
+      <button
+        type="button"
+        data-menu-close
+        aria-label="Close menu"
+        class="p-2 rounded hover:bg-slate-100"
+      >
+        <Icon name="mdi:close" class="w-5 h-5" />
+      </button>
+    </div>
+    <ul
+      class="max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0 divide-y divide-slate-100"
+    >
+      {
+        primarySections.map((section) => (
+          <li>
+            <a
+              href={section.href}
+              class:list={[
+                "flex items-center gap-3 py-4 text-lg",
+                section.id === "routes"
+                  ? "text-green-700 font-semibold"
+                  : "text-slate-700",
+              ]}
+            >
+              <Icon name={section.icon} class="w-5 h-5" />
+              {section.label}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+
+  <div class="max-w-(--breakpoint-xl) mx-auto px-2 lg:px-0 py-3 relative">
+    <nav
+      aria-label="Breadcrumb"
+      class="flex items-center gap-1.5 text-sm flex-wrap"
+    >
+      <a href="/" class="text-slate-500 hover:underline">Tricity Hiking</a>
+      <Icon name="mdi:chevron-right" class="w-3.5 h-3.5 text-slate-400" />
+      <button
+        type="button"
+        data-panel-target="map"
+        class="text-slate-500 hover:underline"
+      >
+        Routes
+      </button>
+      <Icon name="mdi:chevron-right" class="w-3.5 h-3.5 text-slate-400" />
+      <button
+        type="button"
+        data-breadcrumb-switcher-trigger
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="breadcrumb-switcher"
+        class="flex items-center gap-1 font-medium text-slate-900 hover:bg-slate-100 rounded px-1.5 py-0.5 -mx-1.5"
+      >
+        <span data-breadcrumb-current>Map</span>
+        <Icon name="mdi:chevron-down" class="w-4 h-4 text-slate-400" />
+      </button>
+    </nav>
+
+    <div
+      id="breadcrumb-switcher"
+      data-breadcrumb-switcher
+      hidden
+      class="absolute z-30 mt-1 bg-white border border-solid border-slate-200 rounded-lg shadow-lg py-1 min-w-56"
+    >
+      <p
+        data-breadcrumb-switcher-detail-only
+        hidden
+        class="px-3 pt-1.5 pb-1 text-xs uppercase tracking-wide text-slate-400"
+      >
+        This route
+      </p>
+      <button
+        type="button"
+        data-panel-back
+        data-breadcrumb-switcher-detail-only
+        hidden
+        class="w-full text-left flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-50"
+      >
+        <Icon name="mdi:arrow-left" class="w-4 h-4" />
+        Back to list
+      </button>
+      <div
+        data-breadcrumb-switcher-detail-only
+        hidden
+        class="my-1 border-t border-solid border-slate-100"
+      >
+      </div>
+      <p
+        class="px-3 pt-1.5 pb-1 text-xs uppercase tracking-wide text-slate-400"
+      >
+        Sections
+      </p>
+      {
+        routesSubsections.map((section) => (
+          <button
+            type="button"
+            data-panel-target={section.id}
+            class="w-full text-left flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            <Icon name={section.icon} class="w-4 h-4 text-slate-500" />
+            {section.label}
+          </button>
+        ))
+      }
+    </div>
+  </div>
+
+  <main class="pb-10">
+    <RoutesPrototypeMapPanel geojson={mapGeojson} />
+    <RoutesPrototypeListPanel
+      panelId="tricity"
+      heading="Tricity routes"
+      items={tricityItems}
+    />
+    <RoutesPrototypeListPanel
+      panelId="nearby"
+      heading="Nearby routes"
+      items={nearbyItems}
+    />
+
+    <RoutesPrototypeDetailPanel>
+      <button
+        slot="back"
+        type="button"
+        data-panel-back
+        class="flex items-center gap-1 text-sm text-green-700 hover:underline"
+      >
+        <Icon name="mdi:arrow-left" class="w-4 h-4" />
+        Back to list
+      </button>
+    </RoutesPrototypeDetailPanel>
+  </main>
+</PrototypeLayout>
+
+<script>
+  import { initRoutesPrototypeNav } from "../scripts/routesPrototypeNav.client";
+  initRoutesPrototypeNav();
+
+  const menuTrigger = document.querySelector<HTMLButtonElement>(
+    "[data-menu-trigger]",
+  );
+  const menuPanel = document.querySelector<HTMLElement>("[data-menu-panel]");
+  const menuClose =
+    document.querySelector<HTMLButtonElement>("[data-menu-close]");
+
+  const openMenu = () => {
+    if (!menuPanel || !menuTrigger) return;
+    menuPanel.hidden = false;
+    menuTrigger.setAttribute("aria-expanded", "true");
+  };
+  const closeMenu = () => {
+    if (!menuPanel || !menuTrigger) return;
+    menuPanel.hidden = true;
+    menuTrigger.setAttribute("aria-expanded", "false");
+  };
+  menuTrigger?.addEventListener("click", openMenu);
+  menuClose?.addEventListener("click", closeMenu);
+
+  const switcherTrigger = document.querySelector<HTMLButtonElement>(
+    "[data-breadcrumb-switcher-trigger]",
+  );
+  const switcherPanel = document.querySelector<HTMLElement>(
+    "[data-breadcrumb-switcher]",
+  );
+  const detailOnlyEls = Array.from(
+    document.querySelectorAll<HTMLElement>(
+      "[data-breadcrumb-switcher-detail-only]",
+    ),
+  );
+
+  const openSwitcher = () => {
+    if (!switcherPanel || !switcherTrigger) return;
+    const isDetail = document.body.dataset.prototypeActivePanel === "detail";
+    detailOnlyEls.forEach((el) => {
+      el.hidden = !isDetail;
+    });
+    switcherPanel.hidden = false;
+    switcherTrigger.setAttribute("aria-expanded", "true");
+  };
+  const closeSwitcher = () => {
+    if (!switcherPanel || !switcherTrigger) return;
+    switcherPanel.hidden = true;
+    switcherTrigger.setAttribute("aria-expanded", "false");
+  };
+  switcherTrigger?.addEventListener("click", () => {
+    if (switcherPanel?.hidden) openSwitcher();
+    else closeSwitcher();
+  });
+  switcherPanel?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement;
+    if (target.closest("[data-panel-target], [data-panel-back]")) {
+      closeSwitcher();
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement;
+    if (
+      switcherPanel &&
+      !switcherPanel.hidden &&
+      !switcherPanel.contains(target) &&
+      !switcherTrigger?.contains(target)
+    ) {
+      closeSwitcher();
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") return;
+    if (menuPanel && !menuPanel.hidden) {
+      closeMenu();
+      menuTrigger?.focus();
+    }
+    if (switcherPanel && !switcherPanel.hidden) {
+      closeSwitcher();
+      switcherTrigger?.focus();
+    }
+  });
+</script>

--- a/src/scripts/routesPrototypeNav.client.ts
+++ b/src/scripts/routesPrototypeNav.client.ts
@@ -48,17 +48,30 @@ export function initRoutesPrototypeNav(root: ParentNode = document): void {
     root.querySelectorAll<HTMLElement>("[data-detail-id]"),
   );
 
-  const detailFields = {
-    title: root.querySelector<HTMLElement>("[data-detail-field='title']"),
-    description: root.querySelector<HTMLElement>(
-      "[data-detail-field='description']",
-    ),
-    distance: root.querySelector<HTMLElement>("[data-detail-field='distance']"),
-    time: root.querySelector<HTMLElement>("[data-detail-field='time']"),
-    gain: root.querySelector<HTMLElement>("[data-detail-field='gain']"),
-    loss: root.querySelector<HTMLElement>("[data-detail-field='loss']"),
-    image: root.querySelector<HTMLImageElement>("[data-detail-field='image']"),
-  };
+  // Each key here doubles as the `data-detail-field` value on the detail
+  // panel's markup *and* the suffix of the `data-detail-*` attribute on
+  // whichever list item was clicked (e.g. "distance" <-> data-detail-distance),
+  // so a single loop can copy every field instead of one branch per field.
+  const DETAIL_TEXT_FIELDS = [
+    "title",
+    "description",
+    "distance",
+    "time",
+    "gain",
+    "loss",
+  ] as const;
+  type DetailTextField = (typeof DETAIL_TEXT_FIELDS)[number];
+
+  const detailTextFields: Partial<Record<DetailTextField, HTMLElement>> = {};
+  DETAIL_TEXT_FIELDS.forEach((field) => {
+    const el = root.querySelector<HTMLElement>(
+      `[data-detail-field='${field}']`,
+    );
+    if (el) detailTextFields[field] = el;
+  });
+  const detailImageField = root.querySelector<HTMLImageElement>(
+    "[data-detail-field='image']",
+  );
 
   if (panels.length === 0) {
     return;
@@ -145,32 +158,22 @@ export function initRoutesPrototypeNav(root: ParentNode = document): void {
       returnPanel = sourcePanel;
     }
 
+    DETAIL_TEXT_FIELDS.forEach((field) => {
+      const el = detailTextFields[field];
+      if (!el) return;
+      const datasetKey = `detail${field[0].toUpperCase()}${field.slice(1)}`;
+      el.textContent = trigger.dataset[datasetKey] ?? "";
+    });
+
     const title = trigger.dataset.detailTitle ?? "";
 
-    if (detailFields.title) detailFields.title.textContent = title;
-    if (detailFields.description) {
-      detailFields.description.textContent =
-        trigger.dataset.detailDescription ?? "";
-    }
-    if (detailFields.distance) {
-      detailFields.distance.textContent = trigger.dataset.detailDistance ?? "";
-    }
-    if (detailFields.time) {
-      detailFields.time.textContent = trigger.dataset.detailTime ?? "";
-    }
-    if (detailFields.gain) {
-      detailFields.gain.textContent = trigger.dataset.detailGain ?? "";
-    }
-    if (detailFields.loss) {
-      detailFields.loss.textContent = trigger.dataset.detailLoss ?? "";
-    }
-    if (detailFields.image) {
+    if (detailImageField) {
       const src = trigger.dataset.detailImage;
       if (src) {
-        detailFields.image.src = src;
-        detailFields.image.hidden = false;
+        detailImageField.src = src;
+        detailImageField.hidden = false;
       } else {
-        detailFields.image.hidden = true;
+        detailImageField.hidden = true;
       }
     }
 

--- a/src/scripts/routesPrototypeNav.client.ts
+++ b/src/scripts/routesPrototypeNav.client.ts
@@ -1,0 +1,275 @@
+/**
+ * Shared interaction behaviour for the /routes navigation prototypes.
+ *
+ * Every variant (routes1..routes5) renders the same four panels
+ * (`data-panel="map|tricity|nearby|detail"`) and its own chrome of trigger
+ * elements (`data-panel-target="map|tricity|nearby"`). This module wires
+ * panel switching, ARIA state, focus management, a "detail" drill-down
+ * populated from whichever route was clicked, and hash-based deep linking
+ * so each variant behaves like real navigation rather than a slideshow.
+ *
+ * UX rules applied here (see also each page's own comments):
+ * - deep linking / bookmarkability of the current view (location.hash)
+ * - focus is moved to the new panel's heading on navigation, per the
+ *   WAI-ARIA Authoring Practices guidance for client-side route changes
+ * - visited/active state is reflected on every trigger for a given target,
+ *   even when a pattern renders more than one control for it (e.g. a
+ *   sidebar item and a breadcrumb chip)
+ */
+
+export type RoutesPanelId = "map" | "tricity" | "nearby" | "detail";
+
+const PANEL_LABELS: Record<RoutesPanelId, string> = {
+  map: "Map",
+  tricity: "Tricity",
+  nearby: "Nearby",
+  detail: "Route",
+};
+
+interface ActivateOptions {
+  detailTitle?: string;
+  focus?: boolean;
+  updateHash?: boolean;
+  hashSuffix?: string;
+}
+
+export function initRoutesPrototypeNav(root: ParentNode = document): void {
+  const panels = Array.from(root.querySelectorAll<HTMLElement>("[data-panel]"));
+  const triggers = Array.from(
+    root.querySelectorAll<HTMLElement>("[data-panel-target]"),
+  );
+  const breadcrumbSlots = Array.from(
+    root.querySelectorAll<HTMLElement>("[data-breadcrumb-current]"),
+  );
+  const backTriggers = Array.from(
+    root.querySelectorAll<HTMLElement>("[data-panel-back]"),
+  );
+  const detailItems = Array.from(
+    root.querySelectorAll<HTMLElement>("[data-detail-id]"),
+  );
+
+  const detailFields = {
+    title: root.querySelector<HTMLElement>("[data-detail-field='title']"),
+    description: root.querySelector<HTMLElement>(
+      "[data-detail-field='description']",
+    ),
+    distance: root.querySelector<HTMLElement>("[data-detail-field='distance']"),
+    time: root.querySelector<HTMLElement>("[data-detail-field='time']"),
+    gain: root.querySelector<HTMLElement>("[data-detail-field='gain']"),
+    loss: root.querySelector<HTMLElement>("[data-detail-field='loss']"),
+    image: root.querySelector<HTMLImageElement>("[data-detail-field='image']"),
+  };
+
+  if (panels.length === 0) {
+    return;
+  }
+
+  let returnPanel: RoutesPanelId = "tricity";
+
+  function activatePanel(
+    panelId: RoutesPanelId,
+    options: ActivateOptions = {},
+  ) {
+    const {
+      detailTitle,
+      focus = true,
+      updateHash = true,
+      hashSuffix,
+    } = options;
+
+    panels.forEach((panel) => {
+      panel.hidden = panel.dataset.panel !== panelId;
+    });
+
+    triggers.forEach((trigger) => {
+      const isActive = trigger.dataset.panelTarget === panelId;
+      trigger.dataset.state = isActive ? "active" : "inactive";
+
+      if (trigger.getAttribute("role") === "tab") {
+        trigger.setAttribute("aria-selected", String(isActive));
+        trigger.tabIndex = isActive ? 0 : -1;
+      } else if (isActive) {
+        trigger.setAttribute("aria-current", "page");
+      } else {
+        trigger.removeAttribute("aria-current");
+      }
+    });
+
+    const label =
+      panelId === "detail" ? (detailTitle ?? "Route") : PANEL_LABELS[panelId];
+    breadcrumbSlots.forEach((slot) => {
+      slot.textContent = label;
+    });
+
+    if (panelId !== "detail") {
+      returnPanel = panelId;
+    }
+    document.body.dataset.prototypeActivePanel = panelId;
+    document.body.dataset.prototypeReturnPanel = returnPanel;
+
+    if (updateHash) {
+      const hash = `#${panelId}${hashSuffix ? `-${hashSuffix}` : ""}`;
+      if (location.hash !== hash) {
+        history.pushState(null, "", hash);
+      }
+    }
+
+    if (focus) {
+      const activePanel = panels.find(
+        (panel) => panel.dataset.panel === panelId,
+      );
+      const heading = activePanel?.querySelector<HTMLElement>(
+        "[data-panel-heading]",
+      );
+      if (heading) {
+        heading.setAttribute("tabindex", "-1");
+        heading.focus({ preventScroll: false });
+      }
+    }
+
+    // Panels can become visible after having 0 dimensions (hidden
+    // attribute) or after a layout shift (e.g. a sidebar collapsing).
+    // MapLibre only auto-resizes on window resize, so nudge it.
+    window.dispatchEvent(new Event("resize"));
+  }
+
+  function openDetail(
+    trigger: HTMLElement,
+    options: { updateHash?: boolean } = {},
+  ) {
+    const { updateHash = true } = options;
+    const sourcePanel = trigger.closest<HTMLElement>("[data-panel]")?.dataset
+      .panel as RoutesPanelId | undefined;
+
+    if (sourcePanel && sourcePanel !== "detail") {
+      returnPanel = sourcePanel;
+    }
+
+    const title = trigger.dataset.detailTitle ?? "";
+
+    if (detailFields.title) detailFields.title.textContent = title;
+    if (detailFields.description) {
+      detailFields.description.textContent =
+        trigger.dataset.detailDescription ?? "";
+    }
+    if (detailFields.distance) {
+      detailFields.distance.textContent = trigger.dataset.detailDistance ?? "";
+    }
+    if (detailFields.time) {
+      detailFields.time.textContent = trigger.dataset.detailTime ?? "";
+    }
+    if (detailFields.gain) {
+      detailFields.gain.textContent = trigger.dataset.detailGain ?? "";
+    }
+    if (detailFields.loss) {
+      detailFields.loss.textContent = trigger.dataset.detailLoss ?? "";
+    }
+    if (detailFields.image) {
+      const src = trigger.dataset.detailImage;
+      if (src) {
+        detailFields.image.src = src;
+        detailFields.image.hidden = false;
+      } else {
+        detailFields.image.hidden = true;
+      }
+    }
+
+    activatePanel("detail", {
+      detailTitle: title,
+      updateHash,
+      hashSuffix: updateHash ? trigger.dataset.detailId : undefined,
+    });
+  }
+
+  triggers.forEach((trigger) => {
+    trigger.addEventListener("click", (event) => {
+      event.preventDefault();
+      const target = trigger.dataset.panelTarget as RoutesPanelId | undefined;
+      if (target) {
+        activatePanel(target);
+      }
+    });
+  });
+
+  // WAI-ARIA APG roving-tabindex arrow key support for any `role="tab"`
+  // trigger, grouped by its nearest `role="tablist"` ancestor. Applies to
+  // every variant that models its subnav as tabs (routes1's tablist,
+  // routes4's segmented control), at no extra cost to the others.
+  const tabGroups = new Map<Element, HTMLElement[]>();
+  triggers.forEach((trigger) => {
+    if (trigger.getAttribute("role") !== "tab") return;
+    const list = trigger.closest("[role='tablist']");
+    if (!list) return;
+    const group = tabGroups.get(list) ?? [];
+    group.push(trigger);
+    tabGroups.set(list, group);
+  });
+
+  tabGroups.forEach((tabs) => {
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("keydown", (event) => {
+        const key = event.key;
+        if (!["ArrowRight", "ArrowLeft", "Home", "End"].includes(key)) return;
+
+        event.preventDefault();
+        let nextIndex = index;
+        if (key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
+        if (key === "ArrowLeft")
+          nextIndex = (index - 1 + tabs.length) % tabs.length;
+        if (key === "Home") nextIndex = 0;
+        if (key === "End") nextIndex = tabs.length - 1;
+
+        const nextTab = tabs[nextIndex];
+        nextTab.focus();
+        nextTab.click();
+      });
+    });
+  });
+
+  detailItems.forEach((item) => {
+    item.addEventListener("click", (event) => {
+      event.preventDefault();
+      openDetail(item);
+    });
+  });
+
+  backTriggers.forEach((trigger) => {
+    trigger.addEventListener("click", (event) => {
+      event.preventDefault();
+      activatePanel(returnPanel);
+    });
+  });
+
+  window.addEventListener("popstate", () => {
+    applyHash({ updateHash: false });
+  });
+
+  function applyHash(options: { updateHash?: boolean } = {}) {
+    const hash = location.hash.replace(/^#/, "");
+    // Route ids are themselves hyphenated (e.g. "samborowo-glowica"), so
+    // only the *first* hyphen separates the panel id from a detail id.
+    const separatorIndex = hash.indexOf("-");
+    const panelId = (
+      separatorIndex === -1 ? hash : hash.slice(0, separatorIndex)
+    ) as RoutesPanelId | "";
+    const detailId =
+      separatorIndex === -1 ? undefined : hash.slice(separatorIndex + 1);
+
+    if (panelId === "detail" && detailId) {
+      const item = detailItems.find((el) => el.dataset.detailId === detailId);
+      if (item) {
+        openDetail(item, { updateHash: options.updateHash });
+        return;
+      }
+    }
+
+    if (panelId === "map" || panelId === "tricity" || panelId === "nearby") {
+      activatePanel(panelId, { updateHash: options.updateHash, focus: false });
+      return;
+    }
+
+    activatePanel("map", { updateHash: false, focus: false });
+  }
+
+  applyHash({ updateHash: false });
+}

--- a/src/services/getRoutesPrototypeData.ts
+++ b/src/services/getRoutesPrototypeData.ts
@@ -1,0 +1,83 @@
+import { getCollection, getEntry } from "astro:content";
+import { merge } from "./merge";
+import { enhance } from "./enhance";
+import { getLineStringFeature } from "./getLineStringFeature";
+import { mToKm } from "./mToKm";
+import { formatTime } from "./formatTime";
+
+export interface RoutesPrototypeListItem {
+  id: string;
+  title: string;
+  description: string;
+  preview: ImageMetadata | undefined;
+  distanceLabel: string;
+  timeLabel: string;
+  gainLabel: string;
+  lossLabel: string;
+}
+
+async function buildListItems(
+  routes: Awaited<ReturnType<typeof getCollection<"routes">>>,
+) {
+  const items: RoutesPrototypeListItem[] = [];
+  const geojsonFeatures = [];
+
+  for (const route of routes) {
+    const geojsonEntry = await getEntry(route.data.geojson);
+
+    if (!geojsonEntry) {
+      continue;
+    }
+
+    const enhancedGeojson = enhance({
+      collection: geojsonEntry.data,
+      route: route.data,
+    });
+
+    const feature = getLineStringFeature({ collection: enhancedGeojson });
+    const properties = feature?.properties ?? {};
+
+    items.push({
+      id: route.id,
+      title: route.data.title,
+      description: route.data.description,
+      preview: route.data.preview,
+      distanceLabel: `${mToKm(properties.distance ?? 0).toFixed(2)}km`,
+      timeLabel: formatTime(properties.estimatedTime ?? 0),
+      gainLabel: `${(properties.totalGain ?? 0).toFixed(0)}m`,
+      lossLabel: `${(properties.totalLoss ?? 0).toFixed(0)}m`,
+    });
+
+    geojsonFeatures.push(enhancedGeojson);
+  }
+
+  return { items, geojsonFeatures };
+}
+
+/**
+ * Shared data loader for the /routes navigation prototypes.
+ *
+ * Mirrors the fetching done by routes.astro, list.astro and nearby.astro,
+ * but returns plain data (no Astro components), so it can be reused as-is
+ * across the /routes1 .. /routes5 prototype pages.
+ */
+export async function getRoutesPrototypeData() {
+  const allRoutes = await getCollection("routes");
+  const routes = allRoutes.filter((route) => !route.data.draft);
+
+  const tricityRoutes = routes.filter((route) => route.data.tricity);
+  const nearbyRoutes = routes.filter((route) => !route.data.tricity);
+
+  const [tricityResult, nearbyResult] = await Promise.all([
+    buildListItems(tricityRoutes),
+    buildListItems(nearbyRoutes),
+  ]);
+
+  const mapGeojson = merge(tricityResult.geojsonFeatures);
+
+  return {
+    tricityItems: tricityResult.items,
+    nearbyItems: nearbyResult.items,
+    mapGeojson,
+  };
+}


### PR DESCRIPTION
## What

5 throwaway, self-contained prototypes at `/routes1`–`/routes5` (plus an index at `/routes-nav-prototypes`), exploring different navigation patterns for the `/routes` area. Each variant covers **both** the site's top-level menu (Routes/Activities/Food/Transportation/History/Articles) **and** the nested Map/Tricity/Nearby subviews, plus a simulated route-detail drill-down to show a 3rd level of hierarchy.

Nothing here touches the live site — `Layout.astro` and `src/pages/routes.astro` are untouched, and every prototype page carries a `noindex` meta tag plus an on-page banner ("Not linked from the live site") with links to hop between variants.

## The 5 variants

1. **`/routes1`** — Sticky tabs + breadcrumb trail. A refined version of the site's current pattern: accessible ARIA `tablist` (roving tabindex, arrow-key nav) instead of plain links, with a breadcrumb that grows on drill-down.
2. **`/routes2`** — Mega menu. "Routes" becomes a disclosure button whose panel doubles as the section switcher; a "Viewing: X" chip stays visible after closing so switching is never a dead end.
3. **`/routes3`** — Docked sidebar / nav rail. Persistent, collapsible sidebar; the active section auto-expands into a Map/Tricity/Nearby tree, docs-site style. Off-canvas drawer on mobile.
4. **`/routes4`** — Bottom tab bar + segmented control. Mobile-first app shell: primary sections in a thumb-reachable bottom bar (with a "More" overflow sheet, since bottom bars cap out around 5 destinations), an iOS-style segmented control for the Routes subviews, and a bottom-sheet drill-down.
5. **`/routes5`** — Breadcrumb-led minimal chrome. Chrome stripped to a slim bar; primary wayfinding is a path bar ("Tricity Hiking / Routes / Map") whose last segment opens a sibling switcher — Notion/Drive style.

## How it's built

All 5 share one data loader (`getRoutesPrototypeData.ts`), one nav config (`routesPrototypeNav.ts`), and one panel-switching client script (`routesPrototypeNav.client.ts`) so only the chrome/markup differs per variant — behaviour (hash-based deep linking, focus management on navigation, keyboard support for tabs) stays consistent across all of them for a fair side-by-side comparison.

## Verification

- `astro check` — 0 errors
- `astro build` — all 57 pages (including the 5 variants + index) build cleanly
- `vitest` — 25/25 existing tests pass, no regressions
- Ran `/code-review` (Standards + Spec axes in parallel); the one real finding (routes4's segmented control tabs weren't wired to their panels via `aria-controls`/`role=tabpanel`) is fixed in the second commit. Remaining Standards findings were judgement-call duplication (list markup, data fetching, nav config) explicitly acceptable for disposable, side-by-side comparison prototypes that intentionally don't touch production code.
- Visual smoke test via headless Chrome wasn't possible in this sandbox (broken Chrome binary unrelated to the code); verified instead via full production build + structural HTML checks (all 4 panels present per variant, bundled client scripts serve 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)